### PR TITLE
Added remove_broken_browserlayer method to step class.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,14 @@ The ``UpgradeStep`` class has various helper functions:
     Changes the class of an object. It has a special handling for BTreeFolder2Base
     based containers.
 
+``self.remove_broken_browserlayer(name, dottedname)``
+    Removes a browser layer registration whose interface can't be imported any
+    more from the persistent registry.
+    Messages like these on instance boot time can be an indication for this
+    problem:
+    ``WARNING OFS.Uninstalled Could not import class 'IMyProductSpecific' from
+    module 'my.product.interfaces'``
+
 
 Progress logger
 ===============

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added remove_broken_browserlayer method to step class.
+  [lgraf]
 
 
 1.2.1 (2013-04-23)

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -2,9 +2,16 @@ from DateTime import DateTime
 from ftw.upgrade import UpgradeStep
 from ftw.upgrade.interfaces import IUpgradeStep
 from ftw.upgrade.testing import FTW_UPGRADE_FUNCTIONAL_TESTING
+from plone.browserlayer.utils import register_layer
 from Products.CMFCore.utils import getToolByName
 from unittest2 import TestCase
+from zope.interface import Interface
 from zope.interface.verify import verifyClass
+
+
+class IMyProductLayer(Interface):
+    """Dummy class used in test_remove_broken_browserlayer()
+    """
 
 
 class TestUpgradeStep(TestCase):
@@ -329,3 +336,17 @@ class TestUpgradeStep(TestCase):
         self.assertEqual(obj.__class__.__name__, 'ATBTreeFolder')
 
         self.portal.manage_delObjects(['class-migration-test'])
+
+    def test_remove_broken_browserlayer(self):
+        # TODO: Currently, this test doesn't really test that the removal
+        # works, it only checks that the Step method can be called without
+        # causing problems.
+
+        register_layer(IMyProductLayer, 'my.product')
+
+        class Step(UpgradeStep):
+            def __call__(self):
+                self.remove_broken_browserlayer('my.product',
+                                                'IMyProductLayer')
+        Step(self.portal_setup)
+


### PR DESCRIPTION
Removes a browser layer registration whose interface can't be imported any more from the persistent registry.
Messages like these on instance boot time can be an indication for this problem:
`WARNING OFS.Uninstalled Could not import class 'IMyProductSpecific' from module 'my.product.interfaces'`
