### PR TITLE
Implement new ``importProfile`` directive.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,10 @@ Features
   By resolving the dependency graph it is able to optimize the upgrade
   step order so that the upgrade is hassle free.
 
+* **Import profile upgrade steps**: Some times an upgrade step does simply
+  import an upgrade step generic setup profile, especially made for this
+  upgrade step. A new ZCML directive makes this much simpler.
+
 * **Writing upgrades**: The package provides a base upgrade class with
   various helpers for tasks often done in upgrades.
 
@@ -75,6 +79,51 @@ Manage upgrades
 The ``@@manage-upgrades`` view allows to upgrade multiple packages at once:
 
 .. image:: https://github.com/4teamwork/ftw.upgrade/raw/master/docs/manage-upgrades.png
+
+
+
+Import-Profile Upgrade Steps
+============================
+
+Sometimes an upgrade simply imports a little generic setup profile, which is only
+made for this upgrade step. Doing such upgrade steps are often much simpler than doing
+the change in python, because one can simply copy the necessary parts of the new
+default generic setup profile into the upgrade step profile.
+
+Normally, for doing this, one has to register an upgrade step and a generic setup
+profile and write an upgrade step handler importing the profile.
+
+ftw.upgrade makes this much simpler by providing an ``importProfile`` ZCML direvtive
+especially for this specific use case.
+
+Example ``configure.zcml`` meant to be placed in your ``upgrades`` sub-package:
+
+.. code:: xml
+
+    <configure
+        xmlns="http://namespaces.zope.org/zope"
+        xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
+        i18n_domain="my.package">
+
+        <include package="ftw.upgrade" file="meta.zcml" />
+
+        <upgrade-step:importProfile
+            title="Update email_from_address"
+            profile="my.package:default"
+            source="1007"
+            destination="1008"
+            directory="profiles/1008"
+            />
+
+    </configure>
+
+This example upgrade steps updates the ``email_from_address`` property.
+
+A generic setup profile is automatically registered and hooked up with the
+generated upgrade step handler.
+
+Simply put a ``properties.xml`` in the folder ``profiles/1008`` relative to the
+above ``configure.zcml`` and the upgrade step is ready for deployment.
 
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Implement new ``importProfile`` directive for creating upgrade steps
+  that just import a specific upgrade step generic setup profile.
+  [jone]
 
 
 1.5 (2013-08-16)

--- a/ftw/upgrade/meta.zcml
+++ b/ftw/upgrade/meta.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:meta="http://namespaces.zope.org/meta">
+
+    <meta:directives namespace="http://namespaces.zope.org/ftw.upgrade">
+
+        <meta:directive
+            name="importProfile"
+            schema=".zcml.IImportProfileUpgradeStep"
+            handler=".zcml.importProfileUpgradeStep"
+            />
+
+    </meta:directives>
+
+</configure>

--- a/ftw/upgrade/tests/test_meta_import_profile.py
+++ b/ftw/upgrade/tests/test_meta_import_profile.py
@@ -1,0 +1,58 @@
+from Products.CMFCore.utils import getToolByName
+from ftw.upgrade.interfaces import IExecutioner
+from ftw.upgrade.interfaces import IUpgradeInformationGatherer
+from ftw.upgrade.testing import FTW_UPGRADE_FIXTURE
+from plone.app.testing import FunctionalTesting
+from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import applyProfile
+from unittest2 import TestCase
+from zope.component import queryAdapter
+from zope.configuration import xmlconfig
+
+
+BAR_PROFILE = 'ftw.upgrade.tests.profiles:bar'
+
+
+class BarUpgrades(PloneSandboxLayer):
+
+    defaultBases = (FTW_UPGRADE_FIXTURE,)
+
+    def setUpZope(self, app, configurationContext):
+        import ftw.upgrade.tests.profiles
+        xmlconfig.file('configure.zcml', ftw.upgrade.tests.profiles,
+                       context=configurationContext)
+        import ftw.upgrade.tests.upgrades
+        xmlconfig.file('bar.zcml', ftw.upgrade.tests.upgrades,
+                       context=configurationContext)
+
+    def setUpPloneSite(self, portal):
+        applyProfile(portal, BAR_PROFILE)
+
+
+BAR_UPGRADES_FIXTURE = BarUpgrades()
+BAR_UPGRADES_FUNCTIONAL = FunctionalTesting(
+    bases=(BAR_UPGRADES_FIXTURE,), name='FtwUpgrade.exec.bar:Functional')
+
+
+class TestImportProfileUpgradeStepDirective(TestCase):
+
+    layer = BAR_UPGRADES_FUNCTIONAL
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setup_tool = getToolByName(self.portal, 'portal_setup')
+        self.gatherer = queryAdapter(setup_tool, IUpgradeInformationGatherer)
+        self.executioner = queryAdapter(setup_tool, IExecutioner)
+
+    def test_profile_upgrade_step_changes_site_email(self):
+        # The example upgrade step changes the sites email address.
+        portal = self.layer['portal']
+        self.assertEqual('', portal.getProperty('email_from_address'))
+        self.executioner.install([(BAR_PROFILE, self.get_bar_upgrade_ids())])
+        self.assertEqual('foo@bar.com', portal.getProperty('email_from_address'))
+
+    def get_bar_upgrade_ids(self):
+        bar_profile = filter(lambda prof: prof.get('id') == BAR_PROFILE,
+                             self.gatherer.get_upgrades())[0]
+        upgrades = [upgrade.get('id') for upgrade in bar_profile.get('upgrades')]
+        return upgrades

--- a/ftw/upgrade/tests/upgrades/bar.zcml
+++ b/ftw/upgrade/tests/upgrades/bar.zcml
@@ -1,0 +1,16 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
+    i18n_domain="ftw.upgrade">
+
+    <include package="ftw.upgrade" file="meta.zcml" />
+
+    <upgrade-step:importProfile
+        title="Update email address"
+        profile="ftw.upgrade.tests.profiles:bar"
+        source="1"
+        destination="2"
+        directory="profiles/bar-2"
+        />
+
+</configure>

--- a/ftw/upgrade/tests/upgrades/profiles/bar-2/properties.xml
+++ b/ftw/upgrade/tests/upgrades/profiles/bar-2/properties.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<site>
+    <property name="email_from_address" type="string">foo@bar.com</property>
+</site>

--- a/ftw/upgrade/zcml.py
+++ b/ftw/upgrade/zcml.py
@@ -1,0 +1,51 @@
+from Products.CMFPlone.interfaces import IMigratingPloneSiteRoot
+from Products.GenericSetup.interfaces import EXTENSION
+from Products.GenericSetup.zcml import registerProfile
+from Products.GenericSetup.zcml import upgradeStep
+from zope.configuration.fields import Path
+from zope.interface import Interface
+import zope.schema
+
+
+class IImportProfileUpgradeStep(Interface):
+    """Register an upgrade step which imports a generic setup profile
+    specific to this upgrade step.
+    """
+
+    title = zope.schema.TextLine(
+        title=u"Title",
+        required=True)
+
+    description = zope.schema.TextLine(
+        title=u"Upgrade step description",
+        required=False)
+
+    profile = zope.schema.TextLine(
+        title=u"GenericSetup profile id",
+        required=True)
+
+    source = zope.schema.ASCII(
+        title=u"Source version",
+        required=True)
+
+    destination = zope.schema.ASCII(
+        title=u"Destination version",
+        required=True)
+
+    directory = Path(
+        title=u'Path',
+        required=True)
+
+
+def importProfileUpgradeStep(_context, title, profile, source, destination,
+                             directory, description=None):
+    registerProfile(_context, name=destination, title=title,
+                    description=description, directory=directory,
+                    provides=EXTENSION, for_=IMigratingPloneSiteRoot)
+
+    def handler(portal_setup):
+        profileid = 'profile-%s:%s' % (_context.package.__name__, destination)
+        portal_setup.runAllImportStepsFromProfile(profileid, purge_old=False)
+
+    upgradeStep(_context, title=title, profile=profile, handler=handler,
+                description=description, source=source, destination=destination)


### PR DESCRIPTION
For creating upgrade steps that just import a specific upgrade step generic setup profile.

Example:

``` xml
    <upgrade-step:importProfile
        title="Update email_from_address"
        profile="my.package:default"
        source="1007"
        destination="1008"
        directory="profiles/1008"
        />
```

@maethu please take a look at my shiny new directive :wink: 
