### PR TITLE
Fix inplace modification bug in catalog query.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.6 (unreleased)
 ----------------
 
+- Fix inplace modification bug when updating the catalog while
+  iterating over a catalog result.
+  [jone]
+
 - Implement new ``importProfile`` directive for creating upgrade steps
   that just import a specific upgrade step generic setup profile.
   [jone]

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -132,7 +132,7 @@ class UpgradeStep(object):
         are returned.
         """
         catalog = self.getToolByName('portal_catalog')
-        brains = catalog.unrestrictedSearchResults(query)
+        brains = tuple(catalog.unrestrictedSearchResults(query))
 
         if full_objects:
             generator = (self.catalog_unrestricted_get_object(brain)


### PR DESCRIPTION
Example:

``` python
for obj in self.objects({'modified': date}, ''):
    obj.setModificationDate(new_date)
    obj.reindexObject(idxs=['modified'])
```

The above example will probably only iterate over a part of the initial result set because the objects are modified to no longer match the query while iterating over the result set.

The root cause of the problem is that the catalog result set is lazy and it seems to re-query the catalog while iterating over the result set.

The fix is to always get the whole result set and convert it into a tuple before starting any (probably) modifying actions on the result.

@maethu this will fix all of your problems! :wink: 
