### PR TITLE
Tests: Use consistent profile names in test profiles.

### DIFF
--- a/ftw/upgrade/tests/test_executioner.py
+++ b/ftw/upgrade/tests/test_executioner.py
@@ -40,14 +40,14 @@ class TestExecutioner(TestCase):
         verifyClass(IExecutioner, Executioner)
 
     def test_installs_upgrades(self):
-        profileid = 'ftw.upgrade.tests:foo'
+        profileid = 'ftw.upgrade.tests.profiles:foo'
         setup_tool = getToolByName(self.layer['portal'], 'portal_setup')
 
         self.assertEqual(None, queryUtility(IFoo))
         self.assertEqual('unknown',
                          setup_tool.getLastVersionForProfile(profileid))
 
-        upgrades = setup_tool.listUpgrades('ftw.upgrade.tests:foo')
+        upgrades = setup_tool.listUpgrades('ftw.upgrade.tests.profiles:foo')
         self.assertEqual(1, len(upgrades))
         id_ = upgrades[0]['id']
 

--- a/ftw/upgrade/tests/test_post_upgrade.py
+++ b/ftw/upgrade/tests/test_post_upgrade.py
@@ -40,7 +40,7 @@ class TestPostUpgrade(MockTestCase):
         self.portal_setup = getToolByName(
             self.layer['portal'], 'portal_setup')
 
-        profileid = 'ftw.upgrade.tests:foo'
+        profileid = 'ftw.upgrade.tests.profiles:foo'
         foo_upgrades = self.portal_setup.listUpgrades(profileid)
         self.data = [(profileid, [foo_upgrades[0]['id']])]
 

--- a/ftw/upgrade/tests/upgrades/foo.zcml
+++ b/ftw/upgrade/tests/upgrades/foo.zcml
@@ -4,7 +4,7 @@
     i18n_domain="ftw.upgrade">
 
     <genericsetup:upgradeStep
-        profile="ftw.upgrade.tests:foo"
+        profile="ftw.upgrade.tests.profiles:foo"
         source="1"
         destination="2"
         title="Registers foo utility"


### PR DESCRIPTION
The `foo` UpgradeStep was previously registered for the profile `ftw.upgrade.tests:foo`, but that profile is actually called `ftw.upgrade.tests.profiles:foo`.
