### PR TITLE
Update provided interfaces when migrating objects to new class.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Update provided interfaces when migrating objects to new class.
+  [jone]
 
 
 1.7.1 (2014-01-09)

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -9,6 +9,8 @@ from ftw.upgrade.interfaces import IUpgradeStep
 from ftw.upgrade.progresslogger import ProgressLogger
 from ftw.upgrade.utils import SizedGenerator
 from plone.browserlayer.interfaces import ILocalBrowserLayerType
+from zope.interface import directlyProvidedBy
+from zope.interface import directlyProvides
 from zope.interface import implements
 import logging
 
@@ -278,6 +280,9 @@ class UpgradeStep(object):
 
         else:
             parent._p_changed = True
+
+        # Refresh provided interfaces cache
+        directlyProvides(base, directlyProvidedBy(base))
 
     security.declarePrivate('remove_broken_browserlayer')
     def remove_broken_browserlayer(self, name, dottedname):

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -424,6 +424,25 @@ class TestUpgradeStep(TestCase):
         Step(self.portal_setup)
         self.assertEqual('ATBTreeFolder', subfolder.__class__.__name__)
 
+    def test_migrate_class_also_updates_provided_interfaces_info(self):
+        from Products.ATContentTypes.content.link import ATLink
+        from Products.ATContentTypes.interfaces import IATLink
+        from Products.ATContentTypes.interfaces import IATDocument
+
+        obj = create(Builder('document'))
+        self.assertTrue(IATDocument.providedBy(obj))
+        self.assertFalse(IATLink.providedBy(obj))
+
+        class Step(UpgradeStep):
+            def __call__(self):
+                self.migrate_class(obj, ATLink)
+
+        Step(self.portal_setup)
+        self.assertFalse(IATDocument.providedBy(obj),
+                         'IATDocument interface not removed in migration')
+        self.assertTrue(IATLink.providedBy(obj),
+                        'IATLink interface not added in migration')
+
     def test_remove_broken_browserlayer(self):
         # TODO: Currently, this test doesn't really test that the removal
         # works, it only checks that the Step method can be called without


### PR DESCRIPTION
Currently, when migrating classes in upgrade steps using the `migrate_class` helper the `__provides__` cache is not updated, resulting in wrong interfaces.

This PR adds resetting the cache using `directlyProvides`.

/ @maethu 
