### PR TITLE
fix transactionnote

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix TransactionNote beeing to large and fail to commit the transaction.
+  [tschanzt]
 
 
 1.7.2 (2014-02-28)

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -1,4 +1,5 @@
 from AccessControl.SecurityInfo import ClassSecurityInformation
+from Products.Archetypes.utils import transaction_note
 from Products.CMFCore.utils import getToolByName
 from Products.GenericSetup.interfaces import ISetupTool
 from Products.GenericSetup.upgrade import _upgrade_registry
@@ -55,9 +56,9 @@ class Executioner(object):
                 profileid, step.title))
 
         step.doStep(self.portal_setup)
-        transaction_note = '%s -> %s (%s)' % (
+        trans_note = '%s -> %s (%s)' % (
             step.profile, '.'.join(step.dest), step.title)
-        transaction.get().note(transaction_note)
+        transaction_note(trans_note)
 
         msg = "Ran upgrade step %s for profile %s" % (
             step.title, profileid)


### PR DESCRIPTION
@jone this should fix the problem that certain upgrades fail because the transactionnote is to large. But it may cause problem with complete dexterity sites.
