### PR TITLE
Make sure the transaction note does not get too long.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,11 @@ Changelog
 1.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make sure the transaction note does not get too long.
+  Zope limits the transaction note length. By actively managing the transaction note
+  we can provide fallbacks for when it gets too long because a lot of upgrade steps
+  are installed at the same time.
+  [jone]
 
 
 1.7.2 (2014-02-28)

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -4,6 +4,7 @@ from Products.GenericSetup.interfaces import ISetupTool
 from Products.GenericSetup.upgrade import _upgrade_registry
 from ftw.upgrade.interfaces import IExecutioner
 from ftw.upgrade.interfaces import IPostUpgrade
+from ftw.upgrade.transactionnote import TransactionNote
 from ftw.upgrade.utils import format_duration
 from ftw.upgrade.utils import get_sorted_profile_ids
 from zope.component import adapts
@@ -11,7 +12,6 @@ from zope.component import getAdapters
 from zope.interface import implements
 import logging
 import time
-import transaction
 
 
 logger = logging.getLogger('ftw.upgrade')
@@ -55,9 +55,7 @@ class Executioner(object):
                 profileid, step.title))
 
         step.doStep(self.portal_setup)
-        transaction_note = '%s -> %s (%s)' % (
-            step.profile, '.'.join(step.dest), step.title)
-        transaction.get().note(transaction_note)
+        TransactionNote().add_upgrade(profileid, step.dest, step.title)
 
         msg = "Ran upgrade step %s for profile %s" % (
             step.title, profileid)

--- a/ftw/upgrade/tests/test_transactionnote.py
+++ b/ftw/upgrade/tests/test_transactionnote.py
@@ -1,0 +1,65 @@
+from ftw.upgrade.transactionnote import TransactionNote
+from unittest2 import TestCase
+import transaction
+
+
+
+class TestTransactionNote(TestCase):
+
+    def setUp(self):
+        transaction.begin()
+
+    def tearDown(self):
+        self.assertLess(len(transaction.get().description), 65533,
+                        'Transaction note should never be longer than 65533')
+        transaction.abort()
+
+    def test_transaction_note_is_updated(self):
+        note = TransactionNote()
+        note.add_upgrade('my.package:default', ('1','1'), 'Migrate objects')
+        note.add_upgrade('my.package:default', ('1702',), 'Remove utility')
+
+        self.assertEquals(
+            u'my.package:default -> 1.1 (Migrate objects)\n'
+            u'my.package:default -> 1702 (Remove utility)',
+            transaction.get().description)
+
+    def test_description_is_removed_when_note_gets_too_long(self):
+        # Transaction note size is limited to 65533 characters
+        description = 'A' * (65533 / 2)
+
+        note = TransactionNote()
+        note.add_upgrade('my.package:default', ('1000',), description)
+        note.add_upgrade('my.package:default', ('1001',), description)
+
+        # Prevent from printing the very long description in the assertion
+        # message by not using assertIn..
+        assert 'AAAA' not in transaction.get().description, \
+            'Description seems not to be removed from too long' + \
+            ' transaction note.'
+
+        self.assertEquals(
+            u'my.package:default -> 1000\n'
+            u'my.package:default -> 1001',
+            transaction.get().description)
+
+    def test_cropped_when_too_long_even_without_description(self):
+        profileid = 'my.package:default'
+
+        note = TransactionNote()
+        for destination in range(1, (65533 / len(profileid)) + 2):
+            note.add_upgrade(profileid, (str(destination),), '')
+
+        note = transaction.get().description
+
+        expected_start = 'my.package:default -> 1\n'
+        self.assertTrue(
+            note.startswith(expected_start),
+            ('Expected transaction note to start with "%s",'
+             ' but it started with "%s"') % (
+                expected_start, note[:50]))
+
+        self.assertTrue(
+            note.endswith('...'),
+            'Expected transaction note to be cropped, ending with "..." '
+            'but it ends with "%s"' % note[-30:])

--- a/ftw/upgrade/transactionnote.py
+++ b/ftw/upgrade/transactionnote.py
@@ -1,0 +1,47 @@
+import transaction
+
+
+TRANSACTION_NOTE_MAX_LENGTH = 65533
+
+
+class TransactionNote(object):
+    """The zope transaction note is limited to a length of 65533 characters.
+    When installing a lot of upgrades at once, this limitation may be
+    exceeded.
+
+    Transaction not strategy:
+    - Use "profileid -> dest (description)" for each upgrade
+    - when too long, use "profileid -> dest" (without the description)
+    - when still too long, crop at the end, appending "..."
+    """
+
+    def add_upgrade(self, profileid, destination, description):
+        self._upgrades.append({'profileid': profileid,
+                               'destination': '.'.join(destination),
+                               'description': description})
+        self._update_transaction_note()
+
+    def _update_transaction_note(self):
+        message = '\n'.join(self._transaction_messages(True))
+        if len(message) >= TRANSACTION_NOTE_MAX_LENGTH:
+            message = '\n'.join(self._transaction_messages(False))
+
+        if len(message) >= TRANSACTION_NOTE_MAX_LENGTH:
+            message = message[:TRANSACTION_NOTE_MAX_LENGTH-4] + '...'
+
+        transaction.get().description = message
+
+    def _transaction_messages(self, include_description=True):
+        if include_description:
+            template = '%(profileid)s -> %(destination)s (%(description)s)'
+        else:
+            template = '%(profileid)s -> %(destination)s'
+
+        return [template % upgrade for upgrade in self._upgrades]
+
+    @property
+    def _upgrades(self):
+        current_transaction = transaction.get()
+        if not hasattr(current_transaction, 'ftw.upgrade:upgrades'):
+            setattr(current_transaction, 'ftw.upgrade:upgrades', [])
+        return getattr(current_transaction, 'ftw.upgrade:upgrades')


### PR DESCRIPTION
Zope limits the transaction note length. By actively managing the transaction note we can provide fallbacks for when it gets too long because a lot of upgrade steps are installed at the same time.

@Tschanzt I've implemented a more complicated version of your fix in #39.
With this approach we can try to have as much information in the transaction note as possible, with a graceful fallback by first removing the upgrade step descriptions and if it is still to long cropping the note.
