### PR TITLE
Add uninstall_product method to upgrade step class.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -276,6 +276,9 @@ The ``UpgradeStep`` class has various helper functions:
     If a list step names is passed with ``steps`` (e.g. ['actions']),
     only those steps are installed. All steps are installed by default.
 
+``self.uninstall_product(product_name)``
+    Uninstalls a product using the quick installer.
+
 ``self.migrate_class(obj, new_class)``
     Changes the class of an object. It has a special handling for BTreeFolder2Base
     based containers.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ``uninstall_product`` method to upgrade step class.
+  [jone]
 
 
 1.7.2 (2014-02-28)

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -259,6 +259,13 @@ class UpgradeStep(object):
                                                run_dependencies=False,
                                                purge_old=False)
 
+    security.declarePrivate('uninstall_product')
+    def uninstall_product(self, product_name):
+        """Uninstalls a product using the quick installer.
+        """
+        quickinstaller = self.getToolByName('portal_quickinstaller')
+        quickinstaller.uninstallProducts([product_name])
+
     security.declarePrivate('migrate_class')
     def migrate_class(self, obj, new_class):
         """Changes the class of a object and notifies the container so that

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -409,6 +409,22 @@ class TestUpgradeStep(TestCase):
 
         Step(self.portal_setup)
 
+    def test_uninstall_product(self):
+        quickinstaller = getToolByName(self.portal, 'portal_quickinstaller')
+        quickinstaller.installProduct('CMFPlacefulWorkflow')
+
+        def installed_products():
+            for product in quickinstaller.listInstalledProducts():
+                yield product['id']
+
+        class Step(UpgradeStep):
+            def __call__(self):
+                self.uninstall_product('CMFPlacefulWorkflow')
+
+        self.assertIn('CMFPlacefulWorkflow', installed_products())
+        Step(self.portal_setup)
+        self.assertNotIn('CMFPlacefulWorkflow', installed_products())
+
     def test_migrate_class(self):
         from Products.ATContentTypes.content.folder import ATBTreeFolder
 


### PR DESCRIPTION
Packages should be uninstalled using the quick installer (at least when the uninstall profile and external method is done properly).
This PR adds a helper method.

@maethu @deiferni 
