### PR TITLE
Wrap step.objects in a SavepointIterator that creates a savepoint every n items.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,18 +226,23 @@ The ``UpgradeStep`` class has various helper functions:
 ``self.getToolByName(tool_name)``
     Returns the tool with the name ``tool_name`` of the upgraded site.
 
-``self.objects(catalog_query, message, logger=None)``
+``self.objects(catalog_query, message, logger=None, savepoints=None)``
     Queries the catalog (unrestricted) and an iterator with full objects.
     The iterator configures and calls a ``ProgressLogger`` with the
     passed ``message``.
 
+    If set to a non-zero value, the ``savepoints`` argument causes a transaction
+    savepoint to be created every n items. This can be used to keep memory usage
+    in check when creating large transactions.
+
 ``self.catalog_rebuild_index(name)``
     Reindex the ``portal_catalog`` index identified by ``name``.
 
-``self.catalog_reindex_objects(query, idxs=None)``
+``self.catalog_reindex_objects(query, idxs=None, savepoints=None)``
     Reindex all objects found in the catalog with `query`.
     A list of indexes can be passed as `idxs` for limiting the
     indexed indexes.
+    The ``savepoints`` argument will be passed to ``self.objects()``.
 
 ``self.catalog_has_index(name)``
     Returns whether there is a catalog index ``name``.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Wrap step.objects in a SavepointIterator that creates a savepoint every n items.
+  [lgraf]
 
 
 1.9.0 (2014-08-27)

--- a/ftw/upgrade/tests/test_savepoint_iterator.py
+++ b/ftw/upgrade/tests/test_savepoint_iterator.py
@@ -1,0 +1,56 @@
+from ftw.upgrade.utils import SavepointIterator
+from unittest2 import TestCase
+import transaction
+
+
+class TestSavepointIterator(TestCase):
+
+    def setUp(self):
+        self.iterable = [1, 2, 3, 4, 5]
+        self.txn = transaction.get()
+
+    def tearDown(self):
+        self.txn.abort()
+
+    def test_creates_savepoints(self):
+        self.assertEquals(
+            0, self.txn._savepoint_index,
+            'A new transaction should not have any savepoints yet')
+
+        iterator = SavepointIterator.build(self.iterable, threshold=5)
+
+        # Consume entire iterator
+        result = list(iterator)
+
+        self.assertEquals(
+            self.iterable, result,
+            'Iterator should yield every item of `iterable`')
+
+        self.assertEquals(
+            1, self.txn._savepoint_index,
+            'One savepoint should have been created')
+
+    def test_doesnt_create_savepoints_with_threshold_0(self):
+        self.assertEquals(
+            0, self.txn._savepoint_index,
+            'A new transaction should not have any savepoints yet')
+
+        iterator = SavepointIterator.build(self.iterable, threshold=0)
+
+        # Consume entire iterator
+        result = list(iterator)
+
+        self.assertEquals(
+            self.iterable, result,
+            'Iterator should yield every item of `iterable`')
+
+        self.assertEquals(
+            0, self.txn._savepoint_index,
+            'threshold=0 should never create any savepoints')
+
+    def test_instanciating_iterator_with_nonzero_threshold_raises(self):
+        with self.assertRaises(ValueError):
+            SavepointIterator(self.iterable, threshold=0)
+
+        with self.assertRaises(ValueError):
+            SavepointIterator(self.iterable, threshold=None)


### PR DESCRIPTION
This feature can be used to keep memory usage in check when creating large transactions.
- I only updated the method description for `step.objects` in the docs (didn't create a dedicated example demonstrating how to use it). I feel it should be pretty self explanatory and a dedicated example would only lead to a lot of repetition in the docs.
- For the tests I used a plain `unittest2.TestCase` and did an explicit `txn.abort()` in `tearDown()`. I don't think it makes a whole lot of sense booting an entire `PloneSandboxLayer` just to get transaction isolation.
- The phrasing _"the `savepoints` argument causes a transaction savepoint to be created every n items"_ could be better (what's `n`?), but _"causes a transaction savepoint to be created every `savepoint` items"_ also sounds weird.

@jone please review
