### PR TITLE
Update upgrade view ordering for root nodes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,13 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Update upgrade view ordering for root nodes.
+  The dependency graph does not define any order for root
+  profiles (e.g. included in buildout directly), which causes
+  random sorting in the upgrade view for those profiles.
+  This change sorts those root profiles by name without changing
+  the order of profiles which is depended on.
+  [jone]
 
 
 1.10.0 (2014-08-28)

--- a/ftw/upgrade/tests/test_utils.py
+++ b/ftw/upgrade/tests/test_utils.py
@@ -48,6 +48,18 @@ class TestTopologicalSort(TestCase):
         self.assertEqual(None,
                          topological_sort(items, dependencies))
 
+    def test_root_nodes_are_reversed_ordered(self):
+        items = ['policy', 'xy', 'foo']
+
+        self.assertEqual(
+            ['xy', 'policy', 'foo'],
+            topological_sort(items, (('policy', 'foo'),)))
+
+        self.assertEqual(
+            ['xy', 'policy', 'foo'],
+            topological_sort(reversed(items), (('policy', 'foo'),)),
+            'items input order should not change result order')
+
 
 class TestFindCyclicDependencies(TestCase):
 
@@ -110,6 +122,27 @@ class TestSortedProfileIds(MockTestCase):
 
         self.assertEqual(
             ['foo', 'bar', 'baz'],
+            get_sorted_profile_ids(portal_setup))
+
+    def test_root_profiles_are_ordered_by_profile_name(self):
+        """In the this example the profiles "baz" and "xy"
+        have no dependencies to another and thus might be
+        ordered in any order from the graph point of view.
+        However, we want a cosistent ordern and therefore
+        order those root nodes by name.
+        """
+        portal_setup = self.mocker.mock()
+        self.expect(portal_setup.listProfileInfo()).result([
+                {'id': 'baz',
+                 'dependencies': [
+                        'profile-foo']},
+                {'id': 'foo'},
+                {'id': 'xy'}]).count(1, 2)
+
+        self.replay()
+
+        self.assertEqual(
+            ['foo', 'baz', 'xy'],
             get_sorted_profile_ids(portal_setup))
 
     def test_cyclic_dependencies(self):

--- a/ftw/upgrade/utils.py
+++ b/ftw/upgrade/utils.py
@@ -49,6 +49,7 @@ def topological_sort(items, partial_order):
 
     # Step 2 - find all roots (nodes with zero incoming arcs).
     roots = [node for (node, nodeinfo) in graph.items() if nodeinfo[0] == 0]
+    roots.sort()
 
     # step 3 - repeatedly emit a root and remove it from the graph. Removing
     # a node may convert some of the node's direct children into roots.


### PR DESCRIPTION
The dependency graph does not define any order for root profiles (e.g. included in buildout directly), which causes random sorting in the upgrade view for those profiles.
This change sorts those root profiles by name without changing the order of profiles which is depended on.

**Example**
Given these dependencies:
- A => []
- B => [C, D]
- C => []
- D => []
- E => []

In the view the profiles are now always ordered like this:
- A     (alphabetical ordering of root nodes)
- C     (topogical ordering of dependency by B)
- D     (topogical ordering of dependency by B)
- B     (alphabetical ordering of root nodes)
- E     (alphabetical ordering of root nodes)

**Background**
The problem was that the sorting order was not always sorted consistently the same with a similar code base in different zope processes / different servers.

I've also verified that the order of the dependencies in the `metadata.xml` matters. The dependencies at the top of the `metadata.xml` are also ordered at the top of the upgrades view (within the dependency group). The "policy" is always moved to the bottom.

@phgross @deiferni 
/cc @maethu 
