### PR TITLE
Make upgrades appear in undo form again.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.10.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make upgrades appear in undo form again.
+  The transaction note fix in 1.7.4 caused upgrade transaction to not appear in the undo form.
+  [jone]
 
 
 1.10.1 (2014-10-27)

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -1,12 +1,12 @@
 from AccessControl.SecurityInfo import ClassSecurityInformation
-from Products.CMFCore.utils import getToolByName
-from Products.GenericSetup.interfaces import ISetupTool
-from Products.GenericSetup.upgrade import _upgrade_registry
 from ftw.upgrade.interfaces import IExecutioner
 from ftw.upgrade.interfaces import IPostUpgrade
 from ftw.upgrade.transactionnote import TransactionNote
 from ftw.upgrade.utils import format_duration
 from ftw.upgrade.utils import get_sorted_profile_ids
+from Products.CMFCore.utils import getToolByName
+from Products.GenericSetup.interfaces import ISetupTool
+from Products.GenericSetup.upgrade import _upgrade_registry
 from zope.component import adapts
 from zope.component import getAdapters
 from zope.interface import implements
@@ -33,6 +33,8 @@ class Executioner(object):
 
         for adapter in self._get_sorted_post_upgrade_adapters():
             adapter()
+
+        TransactionNote().set_transaction_note()
 
     security.declarePrivate('_upgrade_profile')
     def _upgrade_profile(self, profileid, upgradeids):

--- a/ftw/upgrade/tests/test_executioner.py
+++ b/ftw/upgrade/tests/test_executioner.py
@@ -56,16 +56,20 @@ class TestExecutioner(TestCase):
                          setup_tool.getLastVersionForProfile(profileid))
 
     def test_transaction_note(self):
-        self.install_profile_upgrades('ftw.upgrade.tests.profiles:foo')
-        self.install_profile_upgrades('ftw.upgrade.tests.profiles:bar')
+        transaction.begin()
+        self.install_profile_upgrades('ftw.upgrade.tests.profiles:foo',
+                                      'ftw.upgrade.tests.profiles:bar')
         self.assertEquals(
             u'ftw.upgrade.tests.profiles:foo -> 2 (Registers foo utility)\n'
             u'ftw.upgrade.tests.profiles:bar -> 2 (Update email address)',
             transaction.get().description)
 
-    def install_profile_upgrades(self, profileid):
+    def install_profile_upgrades(self, *profileids):
         setup_tool = getToolByName(self.layer['portal'], 'portal_setup')
         executioner = queryAdapter(setup_tool, IExecutioner)
-        upgrade_ids = [upgrade['id'] for upgrade
-                       in setup_tool.listUpgrades(profileid)]
-        executioner.install([(profileid, upgrade_ids)])
+        upgrade_info = []
+        for profileid in profileids:
+            upgrade_ids = [upgrade['id'] for upgrade
+                           in setup_tool.listUpgrades(profileid)]
+            upgrade_info.append((profileid, upgrade_ids))
+        executioner.install(upgrade_info)

--- a/ftw/upgrade/tests/test_transactionnote.py
+++ b/ftw/upgrade/tests/test_transactionnote.py
@@ -18,6 +18,7 @@ class TestTransactionNote(TestCase):
         note = TransactionNote()
         note.add_upgrade('my.package:default', ('1','1'), 'Migrate objects')
         note.add_upgrade('my.package:default', ('1702',), 'Remove utility')
+        note.set_transaction_note()
 
         self.assertEquals(
             u'my.package:default -> 1.1 (Migrate objects)\n'
@@ -31,6 +32,7 @@ class TestTransactionNote(TestCase):
         note = TransactionNote()
         note.add_upgrade('my.package:default', ('1000',), description)
         note.add_upgrade('my.package:default', ('1001',), description)
+        note.set_transaction_note()
 
         # Prevent from printing the very long description in the assertion
         # message by not using assertIn..
@@ -46,20 +48,22 @@ class TestTransactionNote(TestCase):
     def test_cropped_when_too_long_even_without_description(self):
         profileid = 'my.package:default'
 
+        transaction.get().note('Some notes..')
+
         note = TransactionNote()
         for destination in range(1, (65533 / len(profileid)) + 2):
             note.add_upgrade(profileid, (str(destination),), '')
+        note.set_transaction_note()
 
-        note = transaction.get().description
-
-        expected_start = 'my.package:default -> 1\n'
+        result = transaction.get().description
+        expected_start = 'Some notes..\nmy.package:default -> 1\n'
         self.assertTrue(
-            note.startswith(expected_start),
+            result.startswith(expected_start),
             ('Expected transaction note to start with "%s",'
              ' but it started with "%s"') % (
-                expected_start, note[:50]))
+                expected_start, result[:50]))
 
         self.assertTrue(
-            note.endswith('...'),
+            result.endswith('...'),
             'Expected transaction note to be cropped, ending with "..." '
-            'but it ends with "%s"' % note[-30:])
+            'but it ends with "%s"' % result[-30:])


### PR DESCRIPTION
The transaction note fix in 1.7.4 caused upgrade transaction to not appear in the undo form anymore.

Setting the transaction description directly did somehow cause the transaction to no longer appear in the undo form.
The implementation is therefore changed to use the transactions `note` method instead. It is only called once because `note` appends each message to the existing description.

The new implementation no longer overrides previously noted messages and respects the length of the existing transaction description regarding its length.
