### PR TITLE
Exclude uninstalled products from upgrades view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.10.2 (unreleased)
 -------------------
 
+- Exclude uninstalled products from upgrades view.
+  [jone]
+
 - Make upgrades appear in undo form again.
   The transaction note fix in 1.7.4 caused upgrade transaction to not appear in the undo form.
   [jone]

--- a/ftw/upgrade/gatherer.py
+++ b/ftw/upgrade/gatherer.py
@@ -1,6 +1,7 @@
 from AccessControl.SecurityInfo import ClassSecurityInformation
 from ftw.upgrade.interfaces import IUpgradeInformationGatherer
 from ftw.upgrade.utils import get_sorted_profile_ids
+from Products.CMFCore.utils import getToolByName
 from Products.GenericSetup.interfaces import ISetupTool
 from Products.GenericSetup.upgrade import normalize_version
 from zope.component import adapts
@@ -129,6 +130,17 @@ class UpgradeInformationGatherer(object):
 
     security.declarePrivate('_is_profile_installed')
     def _is_profile_installed(self, profileid):
+        quickinstaller = getToolByName(self.portal_setup, 'portal_quickinstaller')
+        try:
+            profileinfo = self.portal_setup.getProfileInfo(profileid)
+        except KeyError:
+            return False
+
+        product = profileinfo['product']
+        if quickinstaller.isProductInstallable(product) and \
+                not quickinstaller.isProductInstalled(product):
+            return False
+
         version = self.portal_setup.getLastVersionForProfile(profileid)
         return version != 'unknown'
 


### PR DESCRIPTION
When a product is uninstalled with quickinstaller or the addons control panel, the changes are reverted but the generic setup profile version is kept.
We now also ask the quickinstaller if the product of each profile is installed and exclude profiles which belong to an uninstalled product.

Fixes #46 
