### PR TITLE
Reverse post upgrade adapter ordering.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.11.0 (unreleased)
 -------------------
 
+- Reverse post upgrade adapter ordering.
+  The order was reversed, it should execute dependencies first.
+  [jone]
+
 - create-upgrade: Make sure to quote argument passed to bin/upgrade.
   [lgraf]
 

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -99,5 +99,5 @@ class Executioner(object):
                 return cmp(profile_order.index(name_a),
                            profile_order.index(name_b))
 
-        adapters.sort(_sorter)
+        adapters.sort(_sorter, reverse=True)
         return [adapter for name, adapter in adapters]

--- a/ftw/upgrade/tests/test_post_upgrade.py
+++ b/ftw/upgrade/tests/test_post_upgrade.py
@@ -32,7 +32,7 @@ class TestPostUpgrade(UpgradeTestCase):
                  'request_argument': self.portal.REQUEST},
                 execution_info)
 
-    def test_post_upgrade_adapters_are_executed_in_order_of_name(self):
+    def test_post_upgrade_adapters_are_executed_in_order_of_dependencies(self):
         self.package.with_profile(Builder('genericsetup profile')
                                   .with_upgrade(self.default_upgrade()))
         self.package.with_profile(Builder('genericsetup profile')
@@ -67,9 +67,7 @@ class TestPostUpgrade(UpgradeTestCase):
             self.assertEquals([], execution_order)
             self.install_profile_upgrades('the.package:default')
 
-            # XXX the order should actually be reversed.
-            # See https://github.com/4teamwork/ftw.upgrade/issues/59
-            self.assertEquals(['the.package:default',
+            self.assertEquals(['the.package:bar',
                                'the.package:foo',
-                               'the.package:bar'],
+                               'the.package:default'],
                               execution_order)


### PR DESCRIPTION
The order was reversed, it should execute dependencies first.

Fixes #59 