### PR TITLE
Update upgrade step scaffold to support plone.reload.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.11.1 (unreleased)
 -------------------
 
+- Update upgrade step scaffold to support plone.reload.
+  [jone]
+
 - New JSON API implemented, accessible with `/upgrades-api`.
   [jone]
 

--- a/ftw/upgrade/directory/scaffold.py
+++ b/ftw/upgrade/directory/scaffold.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from path import Path
 import inflection
 import os
 
@@ -30,6 +31,8 @@ class UpgradeStepCreator(object):
             inflection.underscore(name))
         step_directory = os.path.join(self.upgrades_directory, step_name)
         os.mkdir(step_directory)
+
+        Path(step_directory).joinpath('__init__.py').touch()
 
         code_path = os.path.join(step_directory, 'upgrade.py')
         with open(code_path, 'w+') as code_file:

--- a/ftw/upgrade/tests/test_command_create.py
+++ b/ftw/upgrade/tests/test_command_create.py
@@ -24,6 +24,9 @@ class TestCreateCommand(CommandTestCase):
 
         code_path = step_path.joinpath('upgrade.py')
         self.assertTrue(code_path.exists(), 'upgrade.py is missing')
+        self.assertTrue(step_path.joinpath('__init__.py').exists(),
+                        'There is no __init__.py in the upgrade directory.'
+                        ' It is important so that plone.reload works.')
         self.maxDiff = True
         self.assertIn('class AddControlpanelAction(UpgradeStep):', code_path.text())
 


### PR DESCRIPTION
There should be an ``__init__.py`` file in the upgrade step directory in order for plone.reload to work properly.