### PR TITLE
Tempfile based authentication negotiation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -689,6 +689,12 @@ The API description is returned when the API action is omitted:
             {
                 "request_method": "GET",
                 "required_params": [],
+                "name": "current_user",
+                "description": "Return the current user when authenticated properly. This can be used for testing authentication."
+            },
+            {
+                "request_method": "GET",
+                "required_params": [],
                 "name": "list_plone_sites",
                 "description": "Returns a list of Plone sites."
             }

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.12.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- New ``bin/upgrade user`` command for testing authentication.
+  [jone]
 
 
 1.12.0 (2015-02-16)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 1.12.1 (unreleased)
 -------------------
 
+- ``bin/upgrade``: automatically authenticate with a tempfile
+  negotiation mechanism when no other authentication information is
+  provided.
+  [jone]
+
 - New ``bin/upgrade user`` command for testing authentication.
   [jone]
 

--- a/ftw/upgrade/command/__init__.py
+++ b/ftw/upgrade/command/__init__.py
@@ -4,6 +4,7 @@ from ftw.upgrade.command import install
 from ftw.upgrade.command import list_cmd
 from ftw.upgrade.command import sites
 from ftw.upgrade.command import touch
+from ftw.upgrade.command import user
 from ftw.upgrade.command.formatter import FlexiFormatter
 from ftw.upgrade.command.terminal import TERMINAL
 from pkg_resources import get_distribution
@@ -94,9 +95,10 @@ class UpgradeCommand(object):
         commands = self.parser.add_subparsers(help='Command')
         create.setup_argparser(commands)
         install.setup_argparser(commands)
+        list_cmd.setup_argparser(commands)
         sites.setup_argparser(commands)
         touch.setup_argparser(commands)
-        list_cmd.setup_argparser(commands)
+        user.setup_argparser(commands)
 
         # Register as last.
         help.setup_argparser(commands)

--- a/ftw/upgrade/command/__init__.py
+++ b/ftw/upgrade/command/__init__.py
@@ -40,8 +40,8 @@ instance must be running, where "ftw.upgrade" is available and the \
 {t.bold}ZOPE INSTANCE DISCOVERY:{t.normal}
     The Zope instance is discovered automatically by searching for all \
 "zope.conf" files in "parts/instance*" of the buildout directory, looking up \
-the instance port and testing whether the port is bound on localhost. If multiple \
-instances are running, the first one running is used.
+the instance port and testing whether the port is bound on localhost.
+If multiple instances are running, the first one running is used.
 
 {t.bold}AUTHENTICATION:{t.normal}
     The JSON API requires authentication as a "Manager" user by using basic \

--- a/ftw/upgrade/command/__init__.py
+++ b/ftw/upgrade/command/__init__.py
@@ -45,13 +45,40 @@ the instance port and testing whether the port is bound on localhost.
 If multiple instances are running, the first one running is used.
 
 {t.bold}AUTHENTICATION:{t.normal}
-    The JSON API requires authentication as a "Manager" user by using basic \
-authentication. The authentication credentials can be passed with the \
-"--auth" argument in form "<username>:<password>" for all commands requiring \
-authentication.
+    There are three authentication options which are tested and used in this \
+order:
 
-    Alternatively, the credentials can be set in the "UPGRADE_AUTHENTICATION" \
-environment variable which will be used as default for the "--auth" argument.
+    - "--auth" argument for basic authentication
+    - "UPGRADE_AUTHENTICATION" environment variable for basic authentication
+    - automatic tempfile based authorization negotiation, using the \
+      automatically generated manager user "system-upgrade".
+
+    {t.bold}"--auth" argument authentication{t.normal}
+    Commands requiring authentication have a "--auth" argument which precede \
+the tempfile negotiation mechanism. \
+It uses basic authentication. \
+The value is expected to be "<username>:<password>". \
+The user should have the "Manager" role.
+
+    {t.bold}"UPGRADE_AUTHENTICATION" environment variable{t.normal}
+    When no "--auth" argument is used, the "UPGRADE_AUTHENTICATION" \
+environment variable is tested for authentication information. \
+This works exactly like the "--auth" argument.
+
+    {t.bold}Tempfile negotiation authentication{t.normal}
+    The automatic tempfile negotiation is used when neither the "--auth" \
+argument nor the "UPGRADE_AUTHENTICATION" environment variable is used. \
+It creates a tempfile, readable only for the owner user and writes a random \
+hash to the file. The filename and the hash is submitted as request header \
+and the backend reads the tempfile and verifies the content.
+    The idea is that if a user has access to the machine with the user \
+running Zope, he can easily create an emergency administator user from the \
+command line and acquire full manager access to the Zope installation. \
+By being able to write the tempfile as this user on the server machine \
+the access is verified.
+    When using this mechanism, a manager user is created at Zope app level, \
+named "system-upgrade". The user has a random password. All requests are \
+then authenticated with this user.
 
 {t.bold}VIRTUAL HOSTING:{t.normal}
     For some upgrade steps it is important that "absolute_url()" returns a \

--- a/ftw/upgrade/command/__init__.py
+++ b/ftw/upgrade/command/__init__.py
@@ -79,6 +79,8 @@ the access is verified.
     When using this mechanism, a manager user is created at Zope app level, \
 named "system-upgrade". The user has a random password. All requests are \
 then authenticated with this user.
+    The temporary file is written to \
+[buildout-directory]var/ftw.upgrade-authentication
 
 {t.bold}VIRTUAL HOSTING:{t.normal}
     For some upgrade steps it is important that "absolute_url()" returns a \

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -90,20 +90,15 @@ def with_api_requestor(func):
     def func_wrapper(args):
         default_auth = os.environ.get('UPGRADE_AUTHENTICATION', None)
         auth_value = args.auth or default_auth
-        if not auth_value:
-            print 'ERROR: No authentication information provided.'
-            print 'Use either the --auth param or the UPGRADE_AUTHENTICATION' + \
-                ' environment variable for providing authentication information' + \
-                ' in the form "<username>:<password>".'
-            sys.exit(1)
-
-        if len(auth_value.split(':')) != 2:
-            print 'ERROR: Invalid authentication information "{0}".'.format(
-                auth_value)
-            print 'A string of form "<username>:<password>" is required.'
-            sys.exit(1)
-
-        auth = HTTPBasicAuth(*auth_value.split(':'))
+        if auth_value:
+            if len(auth_value.split(':')) != 2:
+                print 'ERROR: Invalid authentication information "{0}".'.format(
+                    auth_value)
+                print 'A string of form "<username>:<password>" is required.'
+                sys.exit(1)
+            auth = HTTPBasicAuth(*auth_value.split(':'))
+        else:
+            auth = TempfileAuth()
 
         site = get_plone_site_by_args(args, APIRequestor(auth))
         requestor = APIRequestor(auth, site=site)

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -1,4 +1,5 @@
 from path import Path
+from requests.auth import HTTPBasicAuth
 from requests.exceptions import HTTPError
 from urlparse import urlparse
 import cgi
@@ -15,9 +16,9 @@ class NoRunningInstanceFound(Exception):
 
 class APIRequestor(object):
 
-    def __init__(self, username, password, site=None):
+    def __init__(self, auth, site=None):
         self.session = requests.Session()
-        self.session.auth = (username, password)
+        self.session.auth = auth
         self.site = site
 
     def GET(self, action, site=None, **kwargs):
@@ -76,7 +77,8 @@ def with_api_requestor(func):
             sys.exit(1)
 
         site = get_plone_site_by_args(args, auth_value)
-        requestor = APIRequestor(*auth_value.split(':'), site=site)
+        requestor = APIRequestor(HTTPBasicAuth(*auth_value.split(':')),
+                                 site=site)
         return func(args, requestor)
     func_wrapper.__name__ = func.__name__
     func_wrapper.__doc__ = func.__doc__
@@ -203,6 +205,6 @@ def get_plone_site_by_args(args, auth_value):
 
 
 def get_sites(auth_value):
-    requestor = APIRequestor(*auth_value.split(':'))
+    requestor = APIRequestor(HTTPBasicAuth(*auth_value.split(':')))
     response = requestor.GET('list_plone_sites')
     return response.json()

--- a/ftw/upgrade/command/user.py
+++ b/ftw/upgrade/command/user.py
@@ -1,0 +1,32 @@
+from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
+from ftw.upgrade.command.jsonapi import error_handling
+from ftw.upgrade.command.jsonapi import with_api_requestor
+from ftw.upgrade.command.terminal import TERMINAL
+
+
+DOCS = """
+{t.bold}DESCRIPTION:{t.normal}
+    Test authentication, printing the user you are authenticated with.
+
+{t.bold}EXAMPLES:{t.normal}
+[quote]
+    $ bin/upgrade user --auth admin:admin
+    Authenticated as "admin".
+[/quote]
+""".format(t=TERMINAL).strip()
+
+
+def setup_argparser(commands):
+    command = commands.add_parser(
+        'user',
+        help='Test authentication and print user.',
+        description=DOCS)
+    command.set_defaults(func=sites_command)
+    add_requestor_authentication_argument(command)
+
+
+@with_api_requestor
+@error_handling
+def sites_command(args, requestor):
+    response = requestor.GET('current_user')
+    print 'Authenticated as "{0}".'.format(response.json())

--- a/ftw/upgrade/command/utils.py
+++ b/ftw/upgrade/command/utils.py
@@ -1,5 +1,6 @@
 from path import Path
 import os
+import stat
 import sys
 
 
@@ -26,3 +27,24 @@ def find_package_namespace_path(egginfo):
         top_level_path = top_level_file.read().strip()
 
     return egginfo.dirname().joinpath(top_level_path)
+
+
+def get_tempfile_authentication_directory(directory=None):
+    """Finds the buildout directory and returns the absolute path to the
+    relative directory var/ftw.upgrade-authentication/.
+    If the directory does not exist it is created.
+    """
+    directory = Path(directory) or Path.getcwd()
+    if not directory.joinpath('bin', 'buildout').isfile():
+        return get_tempfile_authentication_directory(directory.parent)
+
+    auth_directory = directory.joinpath('var', 'ftw.upgrade-authentication')
+    if not auth_directory.isdir():
+        auth_directory.mkdir(mode=0700)
+
+    if stat.S_IMODE(auth_directory.stat().st_mode) != 0700:
+        raise ValueError('{0} has invalid mode.'.format(auth_directory))
+    if auth_directory.stat().st_uid != os.getuid():
+        raise ValueError('{0} has an invalid owner.'.format(auth_directory))
+
+    return auth_directory

--- a/ftw/upgrade/jsonapi/configure.zcml
+++ b/ftw/upgrade/jsonapi/configure.zcml
@@ -20,7 +20,8 @@
         for="OFS.interfaces.IApplication"
         class=".zopeapp.ZopeAppAPI"
         permission="zope.Public"
-        allowed_attributes="list_plone_sites"
+        allowed_attributes="current_user
+                            list_plone_sites"
         />
 
 </configure>

--- a/ftw/upgrade/jsonapi/utils.py
+++ b/ftw/upgrade/jsonapi/utils.py
@@ -1,3 +1,8 @@
+from AccessControl import getSecurityManager
+from AccessControl.SecurityManagement import newSecurityManager
+from AccessControl.SecurityManagement import SpecialUsers
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from ftw.upgrade.exceptions import CyclicDependencies
 from ftw.upgrade.exceptions import UpgradeNotFound
 from ftw.upgrade.jsonapi.exceptions import AbortTransactionWithStreamedResponse
@@ -7,11 +12,14 @@ from ftw.upgrade.jsonapi.exceptions import MethodNotAllowed
 from ftw.upgrade.jsonapi.exceptions import MissingParam
 from ftw.upgrade.jsonapi.exceptions import UnauthorizedWrapper
 from ftw.upgrade.jsonapi.exceptions import UpgradeNotFoundWrapper
+from OFS.interfaces import IApplication
 from zExceptions import Unauthorized
 from zope.security import checkPermission
 import inspect
 import json
+import os
 import re
+import tempfile
 import transaction
 
 
@@ -70,6 +78,8 @@ def action(method, rename_params={}):
             with ErrorHandling(self.request.RESPONSE):
                 if self.request.method != method:
                     raise MethodNotAllowed(method)
+
+                perform_tempfile_authentication(self.context, self.request)
 
                 if not checkPermission('cmf.ManagePortal', self.context):
                     raise Unauthorized()
@@ -157,3 +167,54 @@ def get_required_args(argspec):
         return argspec.args[1:]
     else:
         return argspec.args[1:-len(argspec.defaults)]
+
+
+def perform_tempfile_authentication(context, request):
+    """When the "x-ftw.upgrade-tempfile-auth" header is set, authentication is
+    initialized based on a tempfile value for verifying that the client and the
+    server is on the same machine with the same user.
+
+    When necessary, a system-upgrade user is created with Manager role and
+    the security is set to this user.
+    """
+    if getSecurityManager().getUser() != SpecialUsers.nobody:
+        return
+
+    auth_value = request.getHeader('x-ftw.upgrade-tempfile-auth')
+    if not auth_value:
+        return
+
+    validate_tempfile_authentication_header_value(auth_value)
+    user = get_system_upgrade_user(context)
+    newSecurityManager(request, user)
+    transaction.get().setUser(user.getId(), '')
+
+
+def validate_tempfile_authentication_header_value(header_value):
+    header_value = header_value.decode('base64')
+    if not re.match('^ftw.upgrade-authentication\w{6}:\w{64}', header_value):
+        raise ValueError(
+            'tempfile auth: invalid x-ftw.upgrade-tempfile-auth header value.')
+
+    filename, authhash = header_value.split(':')
+    filepath = os.path.join(tempfile.gettempdir(), filename)
+    if not os.path.exists(filepath):
+        raise ValueError('tempfile auth: tempfile does not exist.')
+
+    if os.path.getsize(filepath) != 64:
+        raise ValueError('tempfile auth: tempfile size is invalid.')
+
+    with open(filepath, 'r') as authfile:
+        if authfile.read() != authhash:
+            raise ValueError('tempfile auth: authentication failed.')
+
+
+def get_system_upgrade_user(context):
+    while not IApplication.providedBy(context):
+        context = aq_parent(aq_inner(context))
+
+    acl_users = context.acl_users
+    if not acl_users.getUserById('system-upgrade'):
+        acl_users.userFolderAddUser(
+            'system-upgrade', os.urandom(16).encode('hex'), ['Manager'], None)
+    return acl_users.getUserById('system-upgrade')

--- a/ftw/upgrade/jsonapi/zopeapp.py
+++ b/ftw/upgrade/jsonapi/zopeapp.py
@@ -1,3 +1,4 @@
+from AccessControl import getSecurityManager
 from ftw.upgrade.jsonapi.base import APIView
 from ftw.upgrade.jsonapi.utils import action
 from ftw.upgrade.jsonapi.utils import jsonify
@@ -12,6 +13,14 @@ class ZopeAppAPI(APIView):
         """
 
         return list(self._get_plone_sites())
+
+    @jsonify
+    @action('GET')
+    def current_user(self):
+        """Return the current user when authenticated properly.
+        This can be used for testing authentication.
+        """
+        return getSecurityManager().getUser().getId()
 
     def _get_plone_sites(self):
         overview_view = self.context.restrictedTraverse('plone-overview')

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -275,6 +275,7 @@ class CommandAndInstanceTestCase(JsonApiTestCase, CommandTestCase):
 
     def setUp(self):
         super(CommandAndInstanceTestCase, self).setUp()
+        self.directory.joinpath('var').mkdir_p()
         os.environ['UPGRADE_AUTHENTICATION'] = ':'.join((SITE_OWNER_NAME,
                                                          TEST_USER_PASSWORD))
 

--- a/ftw/upgrade/tests/test_command_jsonapi.py
+++ b/ftw/upgrade/tests/test_command_jsonapi.py
@@ -47,6 +47,11 @@ class TestAPIRequestor(CommandAndInstanceTestCase):
         with self.assertRaises(NoRunningInstanceFound):
             requestor.GET('list_plone_sites')
 
+    def test_basic_authentication(self):
+        requestor = APIRequestor(HTTPBasicAuth(SITE_OWNER_NAME, TEST_USER_PASSWORD))
+        jsondata = requestor.GET('current_user').json()
+        self.assertEqual('admin', jsondata)
+
 
 class TestJsonAPIUtils(CommandAndInstanceTestCase):
 

--- a/ftw/upgrade/tests/test_command_jsonapi.py
+++ b/ftw/upgrade/tests/test_command_jsonapi.py
@@ -6,6 +6,7 @@ from ftw.upgrade.command.jsonapi import NoRunningInstanceFound
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
+from requests.auth import HTTPBasicAuth
 from requests.exceptions import HTTPError
 import os
 
@@ -17,7 +18,7 @@ class TestAPIRequestor(CommandAndInstanceTestCase):
         self.write_zconf_with_test_instance()
 
     def test_GET(self):
-        requestor = APIRequestor(SITE_OWNER_NAME, TEST_USER_PASSWORD)
+        requestor = APIRequestor(HTTPBasicAuth(SITE_OWNER_NAME, TEST_USER_PASSWORD))
         jsondata = requestor.GET('list_plone_sites').json()
         self.assertEqual([{u'id': u'plone',
                            u'path': u'/plone',
@@ -25,7 +26,7 @@ class TestAPIRequestor(CommandAndInstanceTestCase):
                          jsondata)
 
     def test_GET_raises_error(self):
-        requestor = APIRequestor(SITE_OWNER_NAME, TEST_USER_PASSWORD)
+        requestor = APIRequestor(HTTPBasicAuth(SITE_OWNER_NAME, TEST_USER_PASSWORD))
         with self.assertRaises(HTTPError) as cm:
             requestor.GET('wrong_action')
 
@@ -35,13 +36,14 @@ class TestAPIRequestor(CommandAndInstanceTestCase):
             cm.exception.response.json())
 
     def test_GET_with_params(self):
-        requestor = APIRequestor(SITE_OWNER_NAME, TEST_USER_PASSWORD, site='plone')
+        requestor = APIRequestor(HTTPBasicAuth(SITE_OWNER_NAME, TEST_USER_PASSWORD),
+                                 site='plone')
         requestor.GET('get_profile', site='plone',
                       params={'profileid': 'Products.TinyMCE:TinyMCE'})
 
     def test_error_when_no_running_instance_found(self):
         self.layer['root_path'].joinpath('parts/instance').rmtree()
-        requestor = APIRequestor(SITE_OWNER_NAME, TEST_USER_PASSWORD)
+        requestor = APIRequestor(HTTPBasicAuth(SITE_OWNER_NAME, TEST_USER_PASSWORD))
         with self.assertRaises(NoRunningInstanceFound):
             requestor.GET('list_plone_sites')
 

--- a/ftw/upgrade/tests/test_command_jsonapi.py
+++ b/ftw/upgrade/tests/test_command_jsonapi.py
@@ -54,7 +54,7 @@ class TestAPIRequestor(CommandAndInstanceTestCase):
         self.assertEqual('admin', jsondata)
 
     def test_tempfile_authentication(self):
-        requestor = APIRequestor(TempfileAuth())
+        requestor = APIRequestor(TempfileAuth(relative_to=os.getcwd()))
         jsondata = requestor.GET('current_user').json()
         self.assertEqual('system-upgrade', jsondata)
 

--- a/ftw/upgrade/tests/test_command_jsonapi.py
+++ b/ftw/upgrade/tests/test_command_jsonapi.py
@@ -3,6 +3,7 @@ from ftw.upgrade.command.jsonapi import get_api_url
 from ftw.upgrade.command.jsonapi import get_running_instance
 from ftw.upgrade.command.jsonapi import get_zope_url
 from ftw.upgrade.command.jsonapi import NoRunningInstanceFound
+from ftw.upgrade.command.jsonapi import TempfileAuth
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
@@ -51,6 +52,11 @@ class TestAPIRequestor(CommandAndInstanceTestCase):
         requestor = APIRequestor(HTTPBasicAuth(SITE_OWNER_NAME, TEST_USER_PASSWORD))
         jsondata = requestor.GET('current_user').json()
         self.assertEqual('admin', jsondata)
+
+    def test_tempfile_authentication(self):
+        requestor = APIRequestor(TempfileAuth())
+        jsondata = requestor.GET('current_user').json()
+        self.assertEqual('system-upgrade', jsondata)
 
 
 class TestJsonAPIUtils(CommandAndInstanceTestCase):

--- a/ftw/upgrade/tests/test_command_sites.py
+++ b/ftw/upgrade/tests/test_command_sites.py
@@ -1,8 +1,5 @@
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
-from plone.app.testing import SITE_OWNER_NAME
-from plone.app.testing import TEST_USER_PASSWORD
 import json
-import os
 
 
 class TestSitesCommand(CommandAndInstanceTestCase):
@@ -34,23 +31,3 @@ class TestSitesCommand(CommandAndInstanceTestCase):
         self.assertMultiLineEqual(
             'ERROR: No running Plone instance detected.\n',
             output)
-
-    def test_authentication_by_param(self):
-        del os.environ['UPGRADE_AUTHENTICATION']
-        exitcode, output = self.upgrade_script('sites --auth {0}:{1}'.format(
-                SITE_OWNER_NAME, TEST_USER_PASSWORD))
-        self.assertEquals(0, exitcode)
-        self.assertEquals('/plone               Plone site\n', output)
-
-    def test_authentication_is_required(self):
-        del os.environ['UPGRADE_AUTHENTICATION']
-        exitcode, output = self.upgrade_script('sites', assert_exitcode=False)
-        self.assertEquals(1, exitcode)
-        self.assertEquals('ERROR: No authentication information provided.',
-                          output.splitlines()[0])
-
-    def test_valid_authentication_format_is_required(self):
-        exitcode, output = self.upgrade_script('sites --auth=john', assert_exitcode=False)
-        self.assertEquals(1, exitcode)
-        self.assertEquals('ERROR: Invalid authentication information "john".',
-                          output.splitlines()[0])

--- a/ftw/upgrade/tests/test_command_user.py
+++ b/ftw/upgrade/tests/test_command_user.py
@@ -25,12 +25,11 @@ class TestUserCommand(CommandAndInstanceTestCase):
         self.assertEquals(0, exitcode)
         self.assertEquals('Authenticated as "admin".\n', output)
 
-    def test_error_when_not_authenticated(self):
+    def test_tempfile_authentication_fallback(self):
         del os.environ['UPGRADE_AUTHENTICATION']
-        exitcode, output = self.upgrade_script('user', assert_exitcode=False)
-        self.assertEquals(1, exitcode)
-        self.assertEquals('ERROR: No authentication information provided.',
-                          output.splitlines()[0])
+        exitcode, output = self.upgrade_script('user')
+        self.assertEquals(0, exitcode)
+        self.assertEquals('Authenticated as "system-upgrade".\n', output)
 
     def test_valid_authentication_format_is_required(self):
         exitcode, output = self.upgrade_script('user --auth=john', assert_exitcode=False)

--- a/ftw/upgrade/tests/test_command_user.py
+++ b/ftw/upgrade/tests/test_command_user.py
@@ -1,0 +1,39 @@
+from ftw.upgrade.tests.base import CommandAndInstanceTestCase
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+import os
+
+
+class TestUserCommand(CommandAndInstanceTestCase):
+
+    def setUp(self):
+        super(TestUserCommand, self).setUp()
+        self.write_zconf_with_test_instance()
+
+    def test_sites_help(self):
+        self.upgrade_script('user --help')
+
+    def test_prints_authenticated_user(self):
+        exitcode, output = self.upgrade_script('user')
+        self.assertEquals(0, exitcode)
+        self.assertEquals('Authenticated as "admin".\n', output)
+
+    def test_authentication_by_param(self):
+        del os.environ['UPGRADE_AUTHENTICATION']
+        exitcode, output = self.upgrade_script('user --auth {0}:{1}'.format(
+                SITE_OWNER_NAME, TEST_USER_PASSWORD))
+        self.assertEquals(0, exitcode)
+        self.assertEquals('Authenticated as "admin".\n', output)
+
+    def test_error_when_not_authenticated(self):
+        del os.environ['UPGRADE_AUTHENTICATION']
+        exitcode, output = self.upgrade_script('user', assert_exitcode=False)
+        self.assertEquals(1, exitcode)
+        self.assertEquals('ERROR: No authentication information provided.',
+                          output.splitlines()[0])
+
+    def test_valid_authentication_format_is_required(self):
+        exitcode, output = self.upgrade_script('user --auth=john', assert_exitcode=False)
+        self.assertEquals(1, exitcode)
+        self.assertEquals('ERROR: Invalid authentication information "john".',
+                          output.splitlines()[0])

--- a/ftw/upgrade/tests/test_jsonapi_zopeapp.py
+++ b/ftw/upgrade/tests/test_jsonapi_zopeapp.py
@@ -14,7 +14,13 @@ class TestZopeAppJsonApi(JsonApiTestCase):
         self.assert_json_equal(
             {'api_version': 'v1',
              'actions':
-                 [{'name': 'list_plone_sites',
+                 [{'name': 'current_user',
+                   'required_params': [],
+                   'description': 'Return the current user when authenticated properly.'
+                   ' This can be used for testing authentication.',
+                   'request_method': 'GET'},
+
+                  {'name': 'list_plone_sites',
                    'required_params': [],
                    'description': 'Returns a list of Plone sites.',
                    'request_method': 'GET'}]},
@@ -33,6 +39,11 @@ class TestZopeAppJsonApi(JsonApiTestCase):
               'path': '/plone',
               'title': 'Plone site'}],
             browser.json)
+
+    @browsing
+    def test_current_user(self, browser):
+        self.api_request('GET', 'current_user', context=self.app)
+        self.assertEqual('"admin"\n', browser.contents)
 
     @browsing
     def test_requiring_available_api_version_by_url(self, browser):


### PR DESCRIPTION
`bin/upgrade` authentication currently requires to write the administrator password to the command line (-> bash history) or to shell config file (environment variable), which is not very nice (#68).

This implements a tempfile based authentication, used when neither `--auth` param nor `UPGRADE_AUTHENTICATION` environment variable is used.

**Authentication procedure:**
- The client writes a random 64-byte hash to a tempfile and sends the filename and hash as request header to the server.
- The server reads the tempfile by joining the path with `tempfile.gettempdir()` and compares the value.
- The server creates a Zope-level `system-upgrade` user (when it does not exist).
- The server logs in with the `system-upgrade`.

**Requirements and details:**
- Client and server must be on the same machine with the same user.
- The python version and environment configuration (e.g. `$TMP`) is relevant since the client does not submit the full path to the server, both paths are implicitly based on `tempfile.gettempdir()`.
- When the client process is closed, python automatically removes the tempfile.
- The name of the file, the filesize and the hashlength are strictly verified for security.

**Side changes:**
- A new ``current_user`` JSON endpoint tells which user is authenticated with this request.
- A new ``bin/upgrade user`` command tells which user is authenticated (or fails when authentication fails), so that authentication can easily be tested.
- Some internal refactorings to make the changes easier.

@lukasgraf @maethu @deiferni @buchi Please review.
Beside a normal review I'm especially interested in security concerns.

Closes #68 