### PR TITLE
Support Python built without curses support

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.13.1 (unreleased)
 -------------------
 
+- Command: add fake terminal fallback when blessed cannot be loaded.
+  This can happen for example when Python is built without curses support.
+  [jone]
+
 - ``bin/upgrade recook`` command for recooking resources.
   [jone]
 

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -1,4 +1,4 @@
-from ftw.upgrade.command.utils import get_tempfile_authentication_directory
+from ftw.upgrade.utils import get_tempfile_authentication_directory
 from path import Path
 from requests.auth import AuthBase
 from requests.auth import HTTPBasicAuth

--- a/ftw/upgrade/command/terminal.py
+++ b/ftw/upgrade/command/terminal.py
@@ -1,5 +1,30 @@
-from blessed import Terminal
+from functools import partial
 from operator import itemgetter
+
+
+class FakeTerminal(str):
+
+    def __getattr__(self, name):
+        if name == 'length':
+            return len
+        return self
+
+    def __getattribute__(self, name):
+        if name in ('center', 'ljust', 'lstrip', 'rjust', 'rstrip', 'strip'):
+            return lambda text, *a, **kw: getattr(text, name)(*a, **kw)
+        return str.__getattribute__(self, name)
+
+    def __call__(self, text):
+        return text
+
+
+try:
+    from blessed import Terminal
+except ImportError, exc:
+    import sys
+    print >>sys.stderr, 'WARNING: Terminal colorization disabled' + \
+        ' because of ImportError: {0}'.format(exc)
+    Terminal = FakeTerminal
 
 
 TERMINAL = Terminal()

--- a/ftw/upgrade/command/utils.py
+++ b/ftw/upgrade/command/utils.py
@@ -1,6 +1,5 @@
 from path import Path
 import os
-import stat
 import sys
 
 
@@ -27,24 +26,3 @@ def find_package_namespace_path(egginfo):
         top_level_path = top_level_file.read().strip()
 
     return egginfo.dirname().joinpath(top_level_path)
-
-
-def get_tempfile_authentication_directory(directory=None):
-    """Finds the buildout directory and returns the absolute path to the
-    relative directory var/ftw.upgrade-authentication/.
-    If the directory does not exist it is created.
-    """
-    directory = Path(directory) or Path.getcwd()
-    if not directory.joinpath('bin', 'buildout').isfile():
-        return get_tempfile_authentication_directory(directory.parent)
-
-    auth_directory = directory.joinpath('var', 'ftw.upgrade-authentication')
-    if not auth_directory.isdir():
-        auth_directory.mkdir(mode=0700)
-
-    if stat.S_IMODE(auth_directory.stat().st_mode) != 0700:
-        raise ValueError('{0} has invalid mode.'.format(auth_directory))
-    if auth_directory.stat().st_uid != os.getuid():
-        raise ValueError('{0} has an invalid owner.'.format(auth_directory))
-
-    return auth_directory

--- a/ftw/upgrade/jsonapi/utils.py
+++ b/ftw/upgrade/jsonapi/utils.py
@@ -3,7 +3,6 @@ from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import SpecialUsers
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from ftw.upgrade.command.utils import get_tempfile_authentication_directory
 from ftw.upgrade.exceptions import CyclicDependencies
 from ftw.upgrade.exceptions import UpgradeNotFound
 from ftw.upgrade.jsonapi.exceptions import AbortTransactionWithStreamedResponse
@@ -13,6 +12,7 @@ from ftw.upgrade.jsonapi.exceptions import MethodNotAllowed
 from ftw.upgrade.jsonapi.exceptions import MissingParam
 from ftw.upgrade.jsonapi.exceptions import UnauthorizedWrapper
 from ftw.upgrade.jsonapi.exceptions import UpgradeNotFoundWrapper
+from ftw.upgrade.utils import get_tempfile_authentication_directory
 from OFS.interfaces import IApplication
 from zExceptions import Unauthorized
 from zope.security import checkPermission

--- a/ftw/upgrade/tests/test_command_fake_terminal.py
+++ b/ftw/upgrade/tests/test_command_fake_terminal.py
@@ -1,0 +1,56 @@
+from ftw.upgrade.command.terminal import FakeTerminal
+from ftw.upgrade.command.terminal import TERMINAL
+from unittest2 import TestCase
+
+
+class TestFakeTerminal(TestCase):
+    """The FakeTerminal is used instead of the blessed terminal when there are import
+    problems, such as python not built with _curses support.
+    The FakeTerminal should act similar to the Terminal class but not do things such
+    as formatting / colorization.
+    """
+
+    def test_concatenating_colors(self):
+        term = FakeTerminal()
+        self.assertEquals(
+            'foo',
+            term.standout + term.green + term.red_bold + 'foo' + term.normal)
+
+    def test_calling_colors(self):
+        term = FakeTerminal()
+        self.assertEquals(
+            'foo',
+            term.red_bold(term.standout('foo')))
+
+    def test_length(self):
+        self.assertEquals(3, FakeTerminal().length('foo'))
+
+    def test_ljust(self):
+        self.assertEquals(TERMINAL.ljust('foo', 10),
+                          FakeTerminal().ljust('foo', 10))
+
+    def test_ljust(self):
+        self.assertEquals(TERMINAL.ljust('foo', 10),
+                          FakeTerminal().ljust('foo', 10))
+        self.assertEquals(TERMINAL.ljust(u'foo', 10),
+                          FakeTerminal().ljust(u'foo', 10))
+
+    def test_rjust(self):
+        self.assertEquals(TERMINAL.rjust('foo', 10),
+                          FakeTerminal().rjust('foo', 10))
+
+    def test_center(self):
+        self.assertEquals(TERMINAL.center('foo', 10),
+                          FakeTerminal().center('foo', 10))
+
+    def test_strip(self):
+        self.assertEquals(TERMINAL.strip('  foo  '),
+                          FakeTerminal().strip('  foo  '))
+
+    def test_rstrip(self):
+        self.assertEquals(TERMINAL.rstrip('  foo  '),
+                          FakeTerminal().rstrip('  foo  '))
+
+    def test_lstrip(self):
+        self.assertEquals(TERMINAL.lstrip('  foo  '),
+                          FakeTerminal().lstrip('  foo  '))


### PR DESCRIPTION
When Python is built without curses support, an `ImportError` `_curses` is raised, because blessed tries to import `curses`. This error currently also happens when starting the Zope instance.

1. Starting the Zope instance should not import the command stuff. I've therefore moved the shared function `get_tempfile_authentication_directory` to the `utils` module on root level. This will make the instance bootable but the `ImportError` still occurs when running `bin/upgrade`.

2. The `blessed` package just imports `curses` without any fallback. We can therefore not import anything when we don't have `curses` support. Because of that I've implemented a very simple `FakeTerminal` which fakes the terminal calls we use and just does not format anything. There is a test for the `FakeTerminal`, but the full tests are never run with it, I think this would be quite complicated.

Closes #71 

@lukasgraf what do you think?