### PR TITLE
Recook resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -877,6 +877,16 @@ Example for exeuting all proposed upgrades of a Plone site:
     Result: SUCCESS
 
 
+Recook resources
+----------------
+
+CSS and JavaScript resource bundles can be recooked:
+
+.. code:: sh
+
+    $ curl -uadmin:admin -X POST http://localhost:8080/Plone/upgrades-api/recook_resources
+    "OK"
+
 
 Import-Profile Upgrade Steps
 ============================

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.13.1 (unreleased)
 -------------------
 
+- ``bin/upgrade recook`` command for recooking resources.
+  [jone]
+
 - Recook resources after installing upgrades.
   [jone]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.13.1 (unreleased)
 -------------------
 
+- Recook resources after installing upgrades.
+  [jone]
+
 - plone.reload support for upgrade step directory.
   [jone]
 

--- a/ftw/upgrade/command/__init__.py
+++ b/ftw/upgrade/command/__init__.py
@@ -2,6 +2,7 @@ from ftw.upgrade.command import create
 from ftw.upgrade.command import help
 from ftw.upgrade.command import install
 from ftw.upgrade.command import list_cmd
+from ftw.upgrade.command import recook
 from ftw.upgrade.command import sites
 from ftw.upgrade.command import touch
 from ftw.upgrade.command import user
@@ -125,6 +126,7 @@ class UpgradeCommand(object):
         create.setup_argparser(commands)
         install.setup_argparser(commands)
         list_cmd.setup_argparser(commands)
+        recook.setup_argparser(commands)
         sites.setup_argparser(commands)
         touch.setup_argparser(commands)
         user.setup_argparser(commands)

--- a/ftw/upgrade/command/recook.py
+++ b/ftw/upgrade/command/recook.py
@@ -1,0 +1,31 @@
+from ftw.upgrade.command.jsonapi import add_json_argument
+from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
+from ftw.upgrade.command.jsonapi import add_site_path_argument
+from ftw.upgrade.command.jsonapi import error_handling
+from ftw.upgrade.command.jsonapi import with_api_requestor
+from ftw.upgrade.command.terminal import TERMINAL
+
+
+DOCS = """
+{t.bold}DESCRIPTION:{t.normal}
+    Recook CSS and JavaScript resource bundles.
+[quote]
+    $ ./bin/upgrade recook --site Plone
+[/quote]
+""".format(t=TERMINAL).strip()
+
+
+def setup_argparser(commands):
+    command = commands.add_parser(
+        'recook',
+        help='Recook CSS and JavaScript resource bundles.',
+        description=DOCS)
+    command.set_defaults(func=recook_command)
+    add_requestor_authentication_argument(command)
+    add_site_path_argument(command)
+
+
+@with_api_requestor
+@error_handling
+def recook_command(args, requestor):
+    print requestor.POST('recook_resources').json()

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -2,6 +2,7 @@ from AccessControl.SecurityInfo import ClassSecurityInformation
 from ftw.upgrade.interfaces import IExecutioner
 from ftw.upgrade.interfaces import IPostUpgrade
 from ftw.upgrade.interfaces import IUpgradeInformationGatherer
+from ftw.upgrade.resource_registries import recook_resources
 from ftw.upgrade.transactionnote import TransactionNote
 from ftw.upgrade.utils import format_duration
 from ftw.upgrade.utils import get_sorted_profile_ids
@@ -36,6 +37,7 @@ class Executioner(object):
             adapter()
 
         TransactionNote().set_transaction_note()
+        recook_resources()
 
     security.declarePrivate('install_upgrades_by_api_ids')
     def install_upgrades_by_api_ids(self, *upgrade_api_ids):

--- a/ftw/upgrade/jsonapi/configure.zcml
+++ b/ftw/upgrade/jsonapi/configure.zcml
@@ -12,7 +12,8 @@
                             list_profiles_proposing_upgrades
                             list_proposed_upgrades
                             execute_upgrades
-                            execute_proposed_upgrades"
+                            execute_proposed_upgrades
+                            recook_resources"
         />
 
     <browser:page

--- a/ftw/upgrade/jsonapi/plonesite.py
+++ b/ftw/upgrade/jsonapi/plonesite.py
@@ -7,6 +7,7 @@ from ftw.upgrade.jsonapi.exceptions import PloneSiteOutdated
 from ftw.upgrade.jsonapi.exceptions import ProfileNotFound
 from ftw.upgrade.jsonapi.utils import action
 from ftw.upgrade.jsonapi.utils import jsonify
+from ftw.upgrade.resource_registries import recook_resources
 from operator import itemgetter
 from Products.CMFCore.utils import getToolByName
 
@@ -64,6 +65,14 @@ class PloneSiteAPI(APIView):
         self._require_up_to_date_plone_site()
         api_ids = map(itemgetter('api_id'), self._get_proposed_upgrades())
         return self._install_upgrades(*api_ids)
+
+    @jsonify
+    @action('POST')
+    def recook_resources(self):
+        """Recook CSS and JavaScript resource bundles.
+        """
+        recook_resources()
+        return 'OK'
 
     def _refine_profile_info(self, profile):
         return {'id': profile['id'],

--- a/ftw/upgrade/resource_registries.py
+++ b/ftw/upgrade/resource_registries.py
@@ -1,0 +1,8 @@
+from Products.CMFCore.utils import getToolByName
+from zope.component.hooks import getSite
+
+
+def recook_resources():
+    for name in ('portal_css', 'portal_javascripts'):
+        registry = getToolByName(getSite(), name)
+        registry.cookResources()

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -81,6 +81,22 @@ class UpgradeTestCase(TestCase):
     def asset(self, filename):
         return Path(__file__).dirname().joinpath('assets', filename).text()
 
+    @contextmanager
+    def assert_resources_recooked(self):
+        def get_styles():
+            return self.portal.restrictedTraverse(
+                'resourceregistries_styles_view').styles()
+
+        def get_scripts():
+            return self.portal.restrictedTraverse(
+                'resourceregistries_scripts_view').scripts()
+
+        styles = get_styles()
+        scripts = get_scripts()
+        yield
+        self.assertNotEqual(styles, get_styles(), 'Styles are not recooked.')
+        self.assertNotEqual(scripts, get_scripts(), 'Scripts are not recooked.')
+
 
 class CommandTestCase(TestCase):
     layer = COMMAND_LAYER

--- a/ftw/upgrade/tests/test_command_recook.py
+++ b/ftw/upgrade/tests/test_command_recook.py
@@ -1,0 +1,18 @@
+from ftw.upgrade.tests.base import CommandAndInstanceTestCase
+import transaction
+
+
+class TestRecookCommand(CommandAndInstanceTestCase):
+
+    def setUp(self):
+        super(TestRecookCommand, self).setUp()
+        self.write_zconf_with_test_instance()
+
+    def test_help(self):
+        self.upgrade_script('recook --help')
+
+    def test_recook_resources(self):
+        with self.assert_resources_recooked():
+            exitcode, output = self.upgrade_script('recook -s plone')
+            self.assertEqual('OK\n', output)
+            transaction.begin()

--- a/ftw/upgrade/tests/test_executioner.py
+++ b/ftw/upgrade/tests/test_executioner.py
@@ -74,3 +74,12 @@ class TestExecutioner(UpgradeTestCase):
                 u'the.package:default -> 1002 (Update email address)\n'
                 u'the.package:default -> 1003 (Update email from name)',
                 transaction.get().description)
+
+    def test_resources_are_recooked_after_installing_upgrades(self):
+        self.package.with_profile(
+            Builder('genericsetup profile')
+            .with_upgrade(Builder('plone upgrade step').upgrading('1000', to='1001')))
+        with self.package_created():
+            self.install_profile('the.package:default', version='1000')
+            with self.assert_resources_recooked():
+                self.install_profile_upgrades('the.package:default')

--- a/ftw/upgrade/tests/test_jsonapi_plonesite.py
+++ b/ftw/upgrade/tests/test_jsonapi_plonesite.py
@@ -46,7 +46,12 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
                   {'name': 'list_proposed_upgrades',
                    'required_params': [],
                    'description': 'Returns a list of proposed upgrades.',
-                   'request_method': 'GET'}]},
+                   'request_method': 'GET'},
+
+                  {'name': 'recook_resources',
+                   'required_params': [],
+                   'description': 'Recook CSS and JavaScript resource bundles.',
+                   'request_method': 'POST'}]},
 
             browser.json)
 
@@ -382,3 +387,9 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
             self.install_profile('the.package:default', version='1')
             self.api_request('POST', 'execute_proposed_upgrades')
             self.assertIn('Result: FAILURE', browser.contents)
+
+    @browsing
+    def test_recook_resources(self, browser):
+        with self.assert_resources_recooked():
+            self.api_request('POST', 'recook_resources')
+            self.assertEqual('OK', browser.json)

--- a/ftw/upgrade/tests/test_resource_registries.py
+++ b/ftw/upgrade/tests/test_resource_registries.py
@@ -1,0 +1,9 @@
+from ftw.upgrade.resource_registries import recook_resources
+from ftw.upgrade.tests.base import UpgradeTestCase
+
+
+class TestResourceRegistries(UpgradeTestCase):
+
+    def test_recooking_resources(self):
+        with self.assert_resources_recooked():
+            recook_resources()


### PR DESCRIPTION
- Resources are automatically recooked after installing upgrades
- Resources can manually be recooked with `bin/upgrade recook`

Closes #70 (1. and 3.)

/cc @lukasgraf @deiferni 