### PR TITLE
plone.reload support for upgrade step directory.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.13.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- plone.reload support for upgrade step directory.
+  [jone]
 
 
 1.13.0 (2015-02-20)

--- a/ftw/upgrade/directory/scanner.py
+++ b/ftw/upgrade/directory/scanner.py
@@ -46,10 +46,19 @@ class Scanner(object):
 
     def _load_upgrade_step_code(self, upgrade_path):
         path = os.path.dirname(upgrade_path)
+
+        try:
+            fp, pathname, description = imp.find_module('.', [path])
+        except ImportError:
+            pass
+        else:
+            name = '.'.join((self.dottedname, os.path.basename(path)))
+            imp.load_module(name, fp, pathname, description)
+
         fp, pathname, description = imp.find_module('upgrade', [path])
         name = '.'.join((self.dottedname,
-                         os.path.basename(self.directory),
-                         os.path.basename(path)))
+                         os.path.basename(path),
+                         'upgrade'))
 
         module = imp.load_module(name, fp, pathname, description)
         upgrade_steps = tuple(self._find_upgrade_step_classes_in_module(
@@ -86,11 +95,9 @@ class Scanner(object):
         However, it is not relevant for anything to work,
         it just makes Python happy.
         """
-        name = '.'.join((self.dottedname,
-                         os.path.basename(self.directory)))
         try:
             fp, pathname, description = imp.find_module('.', [self.directory])
         except ImportError:
             pass
         else:
-            imp.load_module(name, fp, pathname, description)
+            imp.load_module(self.dottedname, fp, pathname, description)

--- a/ftw/upgrade/tests/builders.py
+++ b/ftw/upgrade/tests/builders.py
@@ -107,9 +107,13 @@ class UpgradeStepBuilder(object):
                     inflection.underscore(name)))
 
         self.package.with_file(
-            os.path.join(step_name, 'upgrade.py'),
-            self.code,
+            os.path.join(step_name, '__init__.py'),
+            '',
             makedirs=True)
+
+        self.package.with_file(
+            os.path.join(step_name, 'upgrade.py'),
+            self.code)
         return step_name
 
     def _register_files_and_dirs_in_package_builder(self, step_name):


### PR DESCRIPTION
Fixes the module names so that plone.reload has a chance to reload the upgrade step code.

The problem was an additional `.upgrades` in the module dottenames and that the upgrade step directory package was not loaded properly.