### PR TITLE
Command: fix instance discover when bound to public network interface.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.14.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Command: fix instance discover when bound to public interface.
+  [jone]
 
 
 1.14.0 (2015-02-24)

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -205,9 +205,9 @@ def find_instance_zconfs(buildout_path):
 
 
 def get_instance_port(zconf):
-    match = re.search(r'address (\d+)', zconf.text())
+    match = re.search(r'address ([\d.]*:)?(\d+)', zconf.text())
     if match:
-        return int(match.group(1))
+        return int(match.group(2))
     return None
 
 

--- a/ftw/upgrade/tests/test_command_jsonapi.py
+++ b/ftw/upgrade/tests/test_command_jsonapi.py
@@ -121,3 +121,13 @@ class TestJsonAPIUtils(CommandAndInstanceTestCase):
             {'port': test_instance_port,
              'path': str(part2)},
             get_running_instance(self.layer['root_path']))
+
+    def test_find_first_running_instance_info_with_network_interface(self):
+        test_instance_port = int(os.environ.get('ZSERVER_PORT', 55001))
+        self.write_zconf('instance1', '1000')
+        part2 = self.write_zconf('instance2',
+                                 '0.0.0.0:{0}'.format(test_instance_port))
+        self.assertEqual(
+            {'port': test_instance_port,
+             'path': str(part2)},
+            get_running_instance(self.layer['root_path']))


### PR DESCRIPTION
When an instance is bound to a public interface, the config is ```address 0.0.0.0:8080``` instead of ```address 8080```.