### PR TITLE
Fix post upgrade ordering which was broken since 1.11.0.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.14.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix post upgrade ordering which was broken since 1.11.0.
+  [jone]
 
 
 1.14.3 (2015-03-29)

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -109,5 +109,5 @@ class Executioner(object):
                 return cmp(profile_order.index(name_a),
                            profile_order.index(name_b))
 
-        adapters.sort(_sorter, reverse=True)
+        adapters.sort(_sorter)
         return [adapter for name, adapter in adapters]


### PR DESCRIPTION
The post upgrade ordering was changed in #64 to be reversed.
The change in #64 was done out of confusion and did the wrong thing.

This changes it back to the right order:

Given the profiles:
- A -> B
- B -> C
- C -> -

The order should be:
C, B, A

This is important so that policies can change things done by its dependencies.

/cc @mbaechtold @lukasgraf 