### PR TITLE
Update quickinstaller product version when upgrading a package.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.14.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Update quickinstaller product version when upgrading a package.
+  [jone]
 
 
 1.14.4 (2015-04-09)

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -57,6 +57,24 @@ class Executioner(object):
         self.portal_setup.setLastVersionForProfile(
             profileid, last_dest_version)
 
+        self._set_quickinstaller_version(profileid)
+
+    security.declarePrivate('_set_quickinstaller_version')
+    def _set_quickinstaller_version(self, profileid):
+        try:
+            profileinfo = self.portal_setup.getProfileInfo(profileid)
+        except KeyError:
+            return
+
+        quickinstaller = getToolByName(self.portal_setup, 'portal_quickinstaller')
+        product = profileinfo['product']
+        if not quickinstaller.isProductInstalled(product):
+            return
+
+        version = quickinstaller.getProductVersion(product)
+        if version:
+            quickinstaller.get(product).installedversion = version
+
     security.declarePrivate('_do_upgrade')
     def _do_upgrade(self, profileid, upgradeid):
         start = time.time()


### PR DESCRIPTION
When installing a product (or profile), quickinstaller stores its version.
When upgrading the package, the version is not updated because it is not reinstalled.

Since upgrading the package should update all things so that it is similar to the new version of the package, we update the package version in quickinstaller to the current product version.

Fixes #79 

/cc @maethu @lukasgraf @simahawk