### PR TITLE
Return context manager to allow "as" statements.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.14.6 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Return context manager to allow "as" statements.
+  [lknoepfel]
 
 
 1.14.5 (2015-05-20)

--- a/ftw/upgrade/browser/manage.py
+++ b/ftw/upgrade/browser/manage.py
@@ -29,6 +29,7 @@ class ResponseLogger(object):
         self.formatter = logging.root.handlers[-1].formatter
         self.handler.setFormatter(self.formatter)
         logging.root.addHandler(self.handler)
+        return self
 
     def __exit__(self, exc_type, exc_value, tb):
         if exc_type is not None:

--- a/ftw/upgrade/jsonapi/utils.py
+++ b/ftw/upgrade/jsonapi/utils.py
@@ -37,7 +37,7 @@ class ErrorHandling(object):
         self.response = response
 
     def __enter__(self):
-        pass
+        return self
 
     def __exit__(self, _type, exc, _traceback):
         if isinstance(exc, AbortTransactionWithStreamedResponse):

--- a/ftw/upgrade/workflow.py
+++ b/ftw/upgrade/workflow.py
@@ -28,6 +28,8 @@ class WorkflowChainUpdater(object):
         self.wfs_and_states_before = self.get_workflows_and_states(
             self.get_objects())
 
+        return self
+
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type:
             return None


### PR DESCRIPTION
Noticed this in the `WorkflowChainUpdater`. You have to return `self` in the `__enter__` method to allow `as` statements like these:
```
with WorkflowChainUpdater(objects) as wcu:
    wcu.stuff = other_stuff
```

I also added this to the other context managers where it wasn't already present.