### PR TITLE
Fix authentication problem with bin/upgrade command.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.14.7 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix authentication problem with bin/upgrade command.
+  [jone]
 
 
 1.14.6 (2015-07-22)

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -50,8 +50,7 @@ class TempfileAuth(AuthBase):
 
     def __call__(self, request):
         self._generate_tempfile()
-        value = ':'.join((os.path.basename(self.authfile.name),
-                          self.authhash)).encode('base64')
+        value = ':'.join((os.path.basename(self.authfile.name), self.authhash))
         request.headers['x-ftw.upgrade-tempfile-auth'] = value
         return request
 

--- a/ftw/upgrade/jsonapi/utils.py
+++ b/ftw/upgrade/jsonapi/utils.py
@@ -192,7 +192,6 @@ def perform_tempfile_authentication(context, request):
 
 
 def validate_tempfile_authentication_header_value(header_value):
-    header_value = header_value.decode('base64')
     if not re.match('^tmp\w{6}:\w{64}', header_value):
         raise ValueError(
             'tempfile auth: invalid x-ftw.upgrade-tempfile-auth header value.')


### PR DESCRIPTION
In certain situations depending on Python version and current
authentication hash the base64 of the authentication header may contain
newlines, which is not valid in HTTP request headers.
Since we do not have special characters in the header value we do not
need to encode it with base64.

Example failure:
```python
Error in test test_tempfile_authentication (ftw.upgrade.tests.test_command_jsonapi.TestAPIRequestor)
Traceback (most recent call last):
  File "/Users/jone/projects/python/cache/eggs/unittest2-0.5.1-py2.7.egg/unittest2/case.py", line 340, in run
    testMethod()
  File "/Users/jone/projects/packages/ftw.upgrade/ftw/upgrade/tests/test_command_jsonapi.py", line 58, in test_tempfile_authentication
    jsondata = requestor.GET('current_user').json()
  File "/Users/jone/projects/packages/ftw.upgrade/ftw/upgrade/command/jsonapi.py", line 30, in GET
    return self._make_request('GET', action, site=site, **kwargs)
  File "/Users/jone/projects/packages/ftw.upgrade/ftw/upgrade/command/jsonapi.py", line 37, in _make_request
    response = self.session.request(method.upper(), url, **kwargs)
  File "/Users/jone/projects/python/cache/eggs/requests-2.7.0-py2.7.egg/requests/sessions.py", line 465, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/jone/projects/python/cache/eggs/requests-2.7.0-py2.7.egg/requests/sessions.py", line 573, in send
    r = adapter.send(request, **kwargs)
  File "/Users/jone/projects/python/cache/eggs/requests-2.7.0-py2.7.egg/requests/adapters.py", line 370, in send
    timeout=timeout
  File "/Users/jone/projects/python/cache/eggs/requests-2.7.0-py2.7.egg/requests/packages/urllib3/connectionpool.py", line 544, in urlopen
    body=body, headers=headers)
  File "/Users/jone/projects/python/cache/eggs/requests-2.7.0-py2.7.egg/requests/packages/urllib3/connectionpool.py", line 349, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/Users/jone/projects/python/buildout.python/parts/opt/lib/python2.7/httplib.py", line 1053, in request
    self._send_request(method, url, body, headers)
  File "/Users/jone/projects/python/buildout.python/parts/opt/lib/python2.7/httplib.py", line 1092, in _send_request
    self.putheader(hdr, value)
  File "/Users/jone/projects/python/buildout.python/parts/opt/lib/python2.7/httplib.py", line 1031, in putheader
    raise ValueError('Invalid header value %r' % (one_value,))
ValueError: Invalid header value 'dG1wOUlIS2thOjkwMDE5NDAxMzYwNTkyN2Y3ZTI3YjkwOGIxNzZkN2JiYWQ0ZjdjOTVkY2Q0Y2Q5\nMzk4NWQ1NzE5YmY1Y2RhYWM=\n'
```