### PR TITLE
Add an afterCommitHook that notifies about the transaction having been committed

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.14.7 (unreleased)
 -------------------
 
+- Add an afterCommitHook that notifies about the transaction having been
+  committed (or aborted) after installing upgrades.
+  [lgraf]
+
 - Fix authentication problem with bin/upgrade command.
   [jone]
 


### PR DESCRIPTION
This PR adds an `afterCommitHook` that simply logs an info message as soon as the transaction has been committed (or aborted).

This is helpful for very long upgrades where the transaction can get quite large, and takes a while to commit. It then is hard to tell when exactly the transaction is done committing.

[Hooks are not persisted across transaction boundaries](https://github.com/zopefoundation/transaction/blob/a97ce37f47f7e5813d450e931e93c8b8b4544ecd/transaction/interfaces.py#L268-L275) - so no special care has to be taken to make sure the hook is removed:

> Calling a hook "consumes" its registration:  hook registrations do not persist across transactions.

@jone @phgross @deiferni 