### PR TITLE
migrate states with wfhistory migration.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.14.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Migrate workflowstates with wfhistory migration & don't set state manually unless necessary.
+  [tschanzt]
 
 
 1.14.7 (2015-08-27)

--- a/ftw/upgrade/workflow.py
+++ b/ftw/upgrade/workflow.py
@@ -98,10 +98,10 @@ class WorkflowChainUpdater(object):
 
             if self.migrate_workflow_history:
                 self._migrate_workflow_history(obj, wf_before, wf_after)
-
-            wf_tool.setStatusOf(wf_after, obj, {
+            else:
+                wf_tool.setStatusOf(wf_after, obj, {
                     'review_state': new_review_state,
-                    'action': '',
+                    'action': 'systemupdate',
                     'actor': 'system',
                     'comments': '',
                     'time': DateTime()})
@@ -128,12 +128,17 @@ class WorkflowChainUpdater(object):
 
         def _migrate_action(entry):
             action = entry.get('action', None)
-            if not action:
-                return
+            if action:
+                actionmapping = self.transition_mapping.get((old_wf, new_wf), {})
+                if action in actionmapping:
+                    entry['action'] = actionmapping[action]
 
-            mapping = self.transition_mapping.get((old_wf, new_wf), {})
-            if action in mapping:
-                entry['action'] = mapping[action]
+            state = entry.get('review_state', None)
+            if state:
+                statemapping = self.review_state_mapping.get((old_wf, new_wf),
+                                                             {})
+                if state in statemapping:
+                    entry['review_state'] = statemapping[state]
 
         def _migrate_entry(entry):
             entry = entry.copy()


### PR DESCRIPTION
This PR aims to migrate the States with the workflowhistory migration. Since the workflowhistory has the workflow as key we still have the old states if something would be wrong with the new workflow. It also removes the requirement to manually set the current State after the migration since it now is the correct one and therefore we don't get an additional historyentry for that.

In the tests I also touched some cases which i didn't have to, but i felt like testing the workflow migration with two workflows where the states are called the same isn't optimal.