### PR TITLE
Refresh references from intid utility to objects after a class migration

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.14.9 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Update references to class-migrated objects in the intid utility.
+  [deiferni]
 
 
 1.14.8 (2015-09-21)

--- a/ftw/upgrade/configure.zcml
+++ b/ftw/upgrade/configure.zcml
@@ -2,6 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.upgrade">
 
     <include package="plone.browserlayer" />
@@ -9,6 +10,10 @@
     <i18n:registerTranslations directory="locales" />
     <include package=".browser" />
     <include package=".jsonapi" />
+    <configure zcml:condition="installed plone.app.intid">
+      <include package=".intid" />
+    </configure>
+
 
     <genericsetup:registerProfile
         name="default"

--- a/ftw/upgrade/events.py
+++ b/ftw/upgrade/events.py
@@ -1,0 +1,8 @@
+from ftw.upgrade.interfaces import IClassMigratedEvent
+from zope.component.interfaces import ObjectEvent
+from zope.interface import implements
+
+
+class ClassMigratedEvent(ObjectEvent):
+
+    implements(IClassMigratedEvent)

--- a/ftw/upgrade/interfaces.py
+++ b/ftw/upgrade/interfaces.py
@@ -3,11 +3,20 @@
 # E0213: Method should have "self" as first argument
 
 
+from zope.component.interfaces import IObjectEvent
 from zope.interface import Interface, Attribute
 
 
 class IUpgradeLayer(Interface):
     """ftw.upgrade specific browser layer.
+    """
+
+
+class IClassMigratedEvent(IObjectEvent):
+    """Fired after the class of an object is migrated.
+
+    This event is fired by an UpgradeStep after its migrate_class method is
+    called.
     """
 
 

--- a/ftw/upgrade/intid/configure.zcml
+++ b/ftw/upgrade/intid/configure.zcml
@@ -1,0 +1,9 @@
+<configure xmlns="http://namespaces.zope.org/zope"
+           i18n_domain="ftw.upgrade">
+
+  <subscriber
+      for="ftw.upgrade.interfaces.IClassMigratedEvent"
+      handler=".migrate.update_intids_after_class_migration"
+      />
+
+</configure>

--- a/ftw/upgrade/intid/migrate.py
+++ b/ftw/upgrade/intid/migrate.py
@@ -1,0 +1,35 @@
+from zope.intid.interfaces import IIntIds
+from zope.component import queryUtility
+
+
+def update_intids_after_class_migration(event):
+    """Update references to class-migrated objects in the intid utility.
+
+    After a class migration all references to the migrated object need to be
+    updated, see:
+    https://www.fourdigits.nl/blog/changing-your-packagename#1411464714874959
+
+    Intids KeyReferenceToPersistent instances keep references to the objects
+    for which they generate an intid. These references need to be updated by
+    telling containing bucket that it has changed. The easiest way to do this
+    is to delete and re-add the object to the tree.
+    """
+
+    intids = queryUtility(IIntIds)
+    # plone.app.intid is in the path but the profile is not installed
+    if not intids:
+        return
+
+    obj = event.object
+    intid = intids.queryId(obj)
+    # the object does not have an intid.
+    if intid is None:
+        return
+
+    reference_to_persistent = intids.refs[intid]
+    # refresh buckets by deleting and re-adding objects.
+    del intids.refs[intid]
+    del intids.ids[reference_to_persistent]
+    intids.refs[intid] = reference_to_persistent
+    intids.ids[reference_to_persistent] = intid
+    reference_to_persistent._p_changed = True

--- a/ftw/upgrade/testing.py
+++ b/ftw/upgrade/testing.py
@@ -76,3 +76,23 @@ COMMAND_AND_UPGRADE_FUNCTIONAL_TESTING = FunctionalTesting(
            set_builder_session_factory(functional_session_factory),
            COMMAND_LAYER),
     name="ftw.upgrade:command_and_functional")
+
+
+class IntIdUpgradeLayer(PloneSandboxLayer):
+
+    defaultBases = (UPGRADE_LAYER, )
+
+    def setUpZope(self, app, configurationContext):
+        import plone.app.intid
+        xmlconfig.file('configure.zcml', plone.app.intid,
+                       context=configurationContext)
+
+    def setUpPloneSite(self, portal):
+        applyProfile(portal, 'plone.app.intid:default')
+
+
+INTID_UPGRADE_LAYER = IntIdUpgradeLayer()
+INTID_UPGRADE_FUNCTIONAL_TESTING = FunctionalTesting(
+    bases=(INTID_UPGRADE_LAYER,
+           set_builder_session_factory(functional_session_factory)),
+    name="ftw.upgrade-intid:functional")

--- a/ftw/upgrade/tests/test_upgrade_step_intids.py
+++ b/ftw/upgrade/tests/test_upgrade_step_intids.py
@@ -1,0 +1,7 @@
+from ftw.upgrade.testing import INTID_UPGRADE_FUNCTIONAL_TESTING
+from ftw.upgrade.tests.test_upgrade_step import TestUpgradeStep
+
+
+class TestUpgradeStepIntids(TestUpgradeStep):
+
+    layer = INTID_UPGRADE_FUNCTIONAL_TESTING

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ tests_require = [
     'ftw.builder >= 1.6.0',
     'plone.testing',
     'plone.app.testing',
+    'plone.app.intid',
 
     'zope.configuration',
     'zc.recipe.egg',


### PR DESCRIPTION
This PR addresses a potential issue with class-migrations and references to objects from the intid utility.

`five.intid` keeps [a reference](https://github.com/plone/five.intid/blob/master/five/intid/keyreference.py#L71) to the object for which an intid is generated. After a class-migration we need to refresh that reference, otherwise the object will have the wrong class wenn loaded from intid `getObejct`/`queryObject` before it is accessed otherwise. In the worst case, i.e. when combined with other changes to the referenced object, this could lead to the object swapping back its class persistently to the old class it had before migration.