### PR TITLE
Remove "blessed" dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -571,6 +571,9 @@ path to the upgrades directory using the ``--path`` argument.
     Download it and place it somewhere in your ``PATH``, cd in the directory and create an upgrade
     step: ``create-upgrade add_control_panel_action``.
 
+If you would like to have colorized output in the terminal, you can install
+the ``colors`` extras (``ftw.upgrade[colors]``).
+
 
 Reordering upgrade steps
 ------------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,8 +2,11 @@ Changelog
 =========
 
 
-1.14.9 (unreleased)
+1.15.0 (unreleased)
 -------------------
+
+- Make "blessed" dependency optional in the "colors" extras.
+  [jone]
 
 - Update references to class-migrated objects in the intid utility.
   [deiferni]

--- a/ftw/upgrade/command/terminal.py
+++ b/ftw/upgrade/command/terminal.py
@@ -20,9 +20,6 @@ class FakeTerminal(str):
 try:
     from blessed import Terminal
 except ImportError, exc:
-    import sys
-    print >>sys.stderr, 'WARNING: Terminal colorization disabled' + \
-        ' because of ImportError: {0}'.format(exc)
     Terminal = FakeTerminal
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.14.9.dev0'
+version = '1.15.0.dev0'
 
 tests_require = [
     'unittest2',
@@ -19,6 +19,10 @@ tests_require = [
     'Products.ATContentTypes',
     'Products.CMFPlacefulWorkflow',
     ]
+
+extras_require = {
+    'colors': ['blessed'],
+    'tests': tests_require}
 
 setup(name='ftw.upgrade',
       version=version,
@@ -53,7 +57,6 @@ setup(name='ftw.upgrade',
       install_requires=[
         'argcomplete',
         'argparse',
-        'blessed',
         'inflection',
         'path.py >= 6.2',
         'requests',
@@ -80,7 +83,7 @@ setup(name='ftw.upgrade',
         ],
 
       tests_require=tests_require,
-      extras_require=dict(tests=tests_require),
+      extras_require=extras_require,
 
       entry_points={
         'z3c.autoinclude.plugin': [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ tests_require = [
     ]
 
 extras_require = {
-    'colors': ['blessed'],
+    'colors': ['blessed <= 1.9.5'],
     'tests': tests_require}
 
 setup(name='ftw.upgrade',

--- a/test-plone-4.3.x-with-blessed.cfg
+++ b/test-plone-4.3.x-with-blessed.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    sources.cfg
+    versions.cfg
+
+package-name = ftw.upgrade
+test-egg = ${buildout:package-name} [tests, colors]


### PR DESCRIPTION
Fixes #87 

No longer have `blessed` as a standard dependency.
`blessed` is used for colorizing the terminal output of `bin/upgrade`.

There is already a fallback for when blessed could not be properly installed (depends on the python installation), so we can just make the dependency optional.

For having colorized terminal output we now need to use the `ftw.upgrade [colors]` extras.