### PR TITLE
Change instance detection to support any name.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.15.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Change instance detection to support any name.
+  Before only "instance*" was supported.
+  [jone]
 
 
 1.15.0 (2015-10-30)

--- a/ftw/upgrade/command/__init__.py
+++ b/ftw/upgrade/command/__init__.py
@@ -41,7 +41,7 @@ instance must be running, where "ftw.upgrade" is available and the \
 
 {t.bold}ZOPE INSTANCE DISCOVERY:{t.normal}
     The Zope instance is discovered automatically by searching for all \
-"zope.conf" files in "parts/instance*" of the buildout directory, looking up \
+"parts/*/etc/zope.conf" files in the buildout directory, looking up \
 the instance port and testing whether the port is bound on localhost.
 If multiple instances are running, the first one running is used.
 

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -200,7 +200,7 @@ def get_running_instance(buildout_path):
 
 
 def find_instance_zconfs(buildout_path):
-    return sorted(buildout_path.glob('parts/instance*/etc/zope.conf'))
+    return sorted(buildout_path.glob('parts/*/etc/zope.conf'))
 
 
 def get_instance_port(zconf):

--- a/ftw/upgrade/tests/test_command_jsonapi.py
+++ b/ftw/upgrade/tests/test_command_jsonapi.py
@@ -131,3 +131,12 @@ class TestJsonAPIUtils(CommandAndInstanceTestCase):
             {'port': test_instance_port,
              'path': str(part2)},
             get_running_instance(self.layer['root_path']))
+
+    def test_find_first_running_instance_info_named_zeoclient(self):
+        test_zeoclient_port = int(os.environ.get('ZSERVER_PORT', 55001))
+        self.write_zconf('zeoclient1', '1000')
+        part2 = self.write_zconf('zeoclient2', test_zeoclient_port)
+        self.assertEqual(
+            {'port': test_zeoclient_port,
+             'path': str(part2)},
+            get_running_instance(self.layer['root_path']))


### PR DESCRIPTION
Zope instances used to only be detected when the were named "instance*".
This change adds support for any name.

Fixes #91
/cc @fredvd