### PR TITLE
Prevented UnicodeEncodeError when piping output of 'bin/upgrade sites'.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.15.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Prevented UnicodeEncodeError when piping output of ``bin/upgrade
+  sites``.  This would fail when a site had non-ascii characters in
+  its title.
+  [maurits]
 
 
 1.15.1 (2015-11-11)

--- a/ftw/upgrade/command/sites.py
+++ b/ftw/upgrade/command/sites.py
@@ -37,4 +37,4 @@ def sites_command(args, requestor):
         print response.text
     else:
         for site in response.json():
-            print site['path'].ljust(20), site['title']
+            print site['path'].ljust(20), site['title'].encode('utf-8')


### PR DESCRIPTION
This would fail when a site had non-ascii characters in its title.

Sample traceback:

```
$ bin/upgrade sites
/cz                  Zeelandia | Suroviny pro pekaře, cukráře a gastronomii
...
$ bin/upgrade sites | less
Traceback (most recent call last):
  File "bin/upgrade", line 314, in <module>
    sys.exit(ftw.upgrade.command.main())
  File "/Users/maurits/clients/zeelandia/zeelandia.landen/develop/ftw.upgrade/ftw/upgrade/command/__init__.py", line 144, in main
    UpgradeCommand()()
  File "/Users/maurits/clients/zeelandia/zeelandia.landen/develop/ftw.upgrade/ftw/upgrade/command/__init__.py", line 140, in __call__
    args.func(args)
  File "/Users/maurits/clients/zeelandia/zeelandia.landen/develop/ftw.upgrade/ftw/upgrade/command/jsonapi.py", line 113, in func_wrapper
    return func(args, requestor)
  File "/Users/maurits/clients/zeelandia/zeelandia.landen/develop/ftw.upgrade/ftw/upgrade/command/jsonapi.py", line 122, in func_wrapper
    return func(*args, **kwargs)
  File "/Users/maurits/clients/zeelandia/zeelandia.landen/develop/ftw.upgrade/ftw/upgrade/command/sites.py", line 40, in sites_command
    print site['path'].ljust(20), site['title']
    UnicodeEncodeError: 'ascii' codec can't encode character u'\u0159' in position 29: ordinal not in range(128)
    /cz
```