### PR TITLE
Added support for installing profiles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,17 +8,18 @@ Changelog
 - Configure logging for the command line utility.  By default print
   only our own logging, on info level or higher.  With the new
   ``--verbose`` option print all loggers (so also from other packages
-  like ``requests``) at debug level and higher.
-  [maurits]
+  like ``requests``) at debug level and higher.  [maurits]
 
-- Added ``plone_upgrade`` command to upgrade a Plone Site.
-  This is what you would manually do in the ``@@plone-upgrade`` view.
-  [maurits]
+- Added ``plone_upgrade`` command to upgrade a Plone Site.  This is
+  what you would manually do in the ``@@plone-upgrade`` view.  [maurits]
+
+- Added support for installing profiles.  Profiles are only applied
+  once.  Example command line: ``bin/upgrade install --site Plone
+  --profiles Products.PloneFormGen:default``.  [maurits]
 
 - Prevented UnicodeEncodeError when piping output of ``bin/upgrade
   sites``.  This would fail when a site had non-ascii characters in
-  its title.
-  [maurits]
+  its title.  [maurits]
 
 
 1.15.1 (2015-11-11)

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -49,6 +49,27 @@ class Executioner(object):
         data = [(upgrade['profile'], [upgrade['id']]) for upgrade in upgrades]
         return self.install(data)
 
+    security.declarePrivate('install_profiles_by_profile_ids')
+    def install_profiles_by_profile_ids(self, *profile_ids):
+        for profile_id in profile_ids:
+            # Starting from GenericSetup 1.8.0 getLastVersionForProfile can
+            # handle profile ids with or without 'profile-' prefix, but we need
+            # to support older versions as well, which only support it without
+            # the prefix.
+            prefix = 'profile-'
+            if profile_id.startswith(prefix):
+                profile_id = profile_id[len(prefix):]
+            installed = self.portal_setup.getLastVersionForProfile(profile_id)
+            if installed != 'unknown':
+                logger.info('Ignoring already installed profile %s.',
+                            profile_id)
+                continue
+            logger.info('Installing profile %s.', profile_id)
+            # For runAllImportStepsFromProfile we still must have 'profile-' at
+            # the start.
+            self.portal_setup.runAllImportStepsFromProfile(prefix + profile_id)
+            logger.info('Done installing profile %s.', profile_id)
+
     security.declarePrivate('_register_after_commit_hook')
     def _register_after_commit_hook(self):
 

--- a/ftw/upgrade/jsonapi/configure.zcml
+++ b/ftw/upgrade/jsonapi/configure.zcml
@@ -12,6 +12,7 @@
                             list_profiles_proposing_upgrades
                             list_proposed_upgrades
                             execute_upgrades
+                            execute_profiles
                             execute_proposed_upgrades
                             plone_upgrade
                             recook_resources"

--- a/ftw/upgrade/jsonapi/exceptions.py
+++ b/ftw/upgrade/jsonapi/exceptions.py
@@ -71,12 +71,19 @@ class CyclicDependenciesWrapper(APIError):
             response_code=500)
 
 
+class ProfileNotAvailable(APIError):
+    def __init__(self, profileid):
+        super(ProfileNotAvailable, self).__init__(
+            'Profile not available',
+            'The profile "{0}" is wrong or not installed'
+            ' on this Plone site.'.format(profileid))
+
+
 class ProfileNotFound(APIError):
     def __init__(self, profileid):
         super(ProfileNotFound, self).__init__(
             'Profile not found',
-            'The profile "{0}" is wrong or not installed'
-            ' on this Plone site.'.format(profileid))
+            'The profile "{0}" is unknown.'.format(profileid))
 
 
 class UpgradeNotFoundWrapper(APIError):


### PR DESCRIPTION
Profiles are only applied once.
Example command line:

`bin/upgrade install --site Plone --profiles Products.PloneFormGen:default`

This implements my request from issue #93.