### PR TITLE
Added '--all-sites' option.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.15.2 (unreleased)
 -------------------
 
+- Added ``--all-sites`` option.  This iterates over all sites and
+  performs the specified command on each of them.  A failing command
+  for one site will stop the entire command.  [maurits]
+
 - Configure logging for the command line utility.  By default print
   only our own logging, on info level or higher.  With the new
   ``--verbose`` option print all loggers (so also from other packages

--- a/ftw/upgrade/command/utils.py
+++ b/ftw/upgrade/command/utils.py
@@ -1,4 +1,7 @@
+from StringIO import StringIO
 from path import Path
+import sys
+import contextlib
 import os
 import sys
 
@@ -26,3 +29,13 @@ def find_package_namespace_path(egginfo):
         top_level_path = top_level_file.read().strip()
 
     return egginfo.dirname().joinpath(top_level_path)
+
+
+@contextlib.contextmanager
+def capture():
+    oldout = sys.stdout
+    try:
+        sys.stdout = StringIO()
+        yield sys.stdout
+    finally:
+        sys.stdout = oldout

--- a/ftw/upgrade/command/utils.py
+++ b/ftw/upgrade/command/utils.py
@@ -1,6 +1,5 @@
 from StringIO import StringIO
 from path import Path
-import sys
 import contextlib
 import os
 import sys


### PR DESCRIPTION
This iterates over all sites and performs the specified command on each of them.

A failing command for one site will stop the entire command.

This was initially rejected in issue #81, but I had a brain wave on how to do it and this seems to work fine. So maybe it is acceptable after all.

I have a Zope instance with 14 Plone Sites, so this would be nice to have. :-)