### PR TITLE
Configure logging for the command line utility.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 1.15.2 (unreleased)
 -------------------
 
+- Configure logging for the command line utility.  By default print
+  only our own logging, on info level or higher.  With the new
+  ``--verbose`` option print all loggers (so also from other packages
+  like ``requests``) at debug level and higher.
+  [maurits]
+
 - Added ``plone_upgrade`` command to upgrade a Plone Site.
   This is what you would manually do in the ``@@plone-upgrade`` view.
   [maurits]

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -76,6 +76,9 @@ def add_requestor_authentication_argument(argparse_command):
 
 
 def add_site_path_argument(argparse_command):
+    argparse_command.add_argument(
+        '--verbose', '-v', action='store_true',
+        help='Verbose logging.')
     group = argparse_command.add_mutually_exclusive_group(required=True)
     group.add_argument(
         '--site', '-s',


### PR DESCRIPTION
By default print only our own logging, on info level or higher.  With the new `--verbose` option print all loggers (so also from other packages like `requests`) at debug level and higher.

With this added, the `--all-sites` option from pull request #99 will visibly log which site it is currently handling.

This is probably my last pull request of this day. ;-)