### PR TITLE
Add ``bin/upgrade plone_upgrade_needed`` command.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -940,6 +940,12 @@ Example for upgrading Plone when no upgrade is needed:
     $ curl -uadmin:admin -X POST "http://localhost:8080/test/upgrades-api/plone_upgrade"
     "Plone Site was already up to date."
 
+For checking whether a Plone upgrade is needed, you can do:
+
+.. code:: sh
+
+    $ curl -uadmin:admin -X POST "http://localhost:8080/test/upgrades-api/plone_upgrade_needed"
+
 
 Recook resources
 ----------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.16.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add ``bin/upgrade plone_upgrade_needed`` command.  [jone]
 
 
 1.16.3 (2016-01-22)

--- a/ftw/upgrade/command/__init__.py
+++ b/ftw/upgrade/command/__init__.py
@@ -3,6 +3,7 @@ from ftw.upgrade.command import help
 from ftw.upgrade.command import install
 from ftw.upgrade.command import list_cmd
 from ftw.upgrade.command import plone_upgrade
+from ftw.upgrade.command import plone_upgrade_needed
 from ftw.upgrade.command import recook
 from ftw.upgrade.command import sites
 from ftw.upgrade.command import touch
@@ -13,8 +14,8 @@ from ftw.upgrade.command.utils import capture
 from pkg_resources import get_distribution
 import argcomplete
 import argparse
-import logging
 import json
+import logging
 import sys
 
 
@@ -132,6 +133,7 @@ class UpgradeCommand(object):
         install.setup_argparser(commands)
         list_cmd.setup_argparser(commands)
         plone_upgrade.setup_argparser(commands)
+        plone_upgrade_needed.setup_argparser(commands)
         recook.setup_argparser(commands)
         sites.setup_argparser(commands)
         touch.setup_argparser(commands)

--- a/ftw/upgrade/command/plone_upgrade_needed.py
+++ b/ftw/upgrade/command/plone_upgrade_needed.py
@@ -1,0 +1,38 @@
+from contextlib import closing
+from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
+from ftw.upgrade.command.jsonapi import add_site_path_argument
+from ftw.upgrade.command.jsonapi import error_handling
+from ftw.upgrade.command.jsonapi import with_api_requestor
+from ftw.upgrade.command.terminal import TERMINAL
+import sys
+
+
+DOCS = """
+{t.bold}DESCRIPTION:{t.normal}
+    Tells whether the Plone-site needs to be upgraded.
+
+{t.bold}EXAMPLES:{t.normal}
+[quote]
+$ bin/upgrade plone_upgrade_needed --site Plone
+[/quote]
+
+""".format(t=TERMINAL).strip()
+
+
+def setup_argparser(commands):
+    command = commands.add_parser(
+        'plone_upgrade_needed',
+        help='Should the Plone site be upgraded?',
+        description=DOCS)
+    command.set_defaults(func=plone_upgrade_command)
+    add_requestor_authentication_argument(command)
+    add_site_path_argument(command)
+
+
+@with_api_requestor
+@error_handling
+def plone_upgrade_command(args, requestor):
+    response = requestor.GET('plone_upgrade_needed')
+    print response.text
+    if response.text.strip() not in ('true', 'false'):
+        sys.exit(3)

--- a/ftw/upgrade/jsonapi/configure.zcml
+++ b/ftw/upgrade/jsonapi/configure.zcml
@@ -15,6 +15,7 @@
                             execute_profiles
                             execute_proposed_upgrades
                             plone_upgrade
+                            plone_upgrade_needed
                             recook_resources"
         />
 

--- a/ftw/upgrade/jsonapi/plonesite.py
+++ b/ftw/upgrade/jsonapi/plonesite.py
@@ -102,6 +102,14 @@ class PloneSiteAPI(APIView):
         portal_migration.upgrade(swallow_errors=False)
         return 'Plone Site has been updated.'
 
+    @jsonify
+    @action('GET')
+    def plone_upgrade_needed(self):
+        """Returns "true" when Plone needs to be upgraded.
+        """
+        portal_migration = getToolByName(self.context, 'portal_migration')
+        return bool(portal_migration.needUpgrading())
+
     def _refine_profile_info(self, profile):
         return {'id': profile['id'],
                 'title': profile['title'],

--- a/ftw/upgrade/tests/test_command_plone_upgrade_needed.py
+++ b/ftw/upgrade/tests/test_command_plone_upgrade_needed.py
@@ -1,0 +1,30 @@
+from ftw.upgrade.tests.base import CommandAndInstanceTestCase
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.factory import _DEFAULT_PROFILE
+import transaction
+
+
+class TestPloneUpgradeNeededCommand(CommandAndInstanceTestCase):
+
+    def setUp(self):
+        super(TestPloneUpgradeNeededCommand, self).setUp()
+        self.write_zconf_with_test_instance()
+
+    def test_help(self):
+        self.upgrade_script('plone_upgrade_needed --help')
+
+    def test_plone_upgrade_already_uptodate(self):
+        exitcode, output = self.upgrade_script(
+            'plone_upgrade_needed -s plone')
+        self.assertEquals(0, exitcode)
+        self.assertIn(u'false', output)
+
+    def test_plone_upgrade_needed(self):
+        setup = getToolByName(self.portal, 'portal_setup')
+        setup.setLastVersionForProfile(_DEFAULT_PROFILE, '4')
+        transaction.commit()
+
+        exitcode, output = self.upgrade_script(
+            'plone_upgrade_needed -s plone')
+        self.assertEquals(0, exitcode)
+        self.assertIn(u'true', output)

--- a/ftw/upgrade/tests/test_jsonapi_plonesite.py
+++ b/ftw/upgrade/tests/test_jsonapi_plonesite.py
@@ -3,6 +3,7 @@ from ftw.builder import Builder
 from ftw.testbrowser import browsing
 from ftw.upgrade.tests.base import JsonApiTestCase
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.factory import _DEFAULT_PROFILE
 import re
 import transaction
 
@@ -57,7 +58,12 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
                   {'name': 'plone_upgrade',
                    'required_params': [],
                    'description': 'Upgrade the Plone Site. This is what you would manually do in the @@plone-upgrade view.',
-                  'request_method': 'POST'},
+                   'request_method': 'POST'},
+
+                  {'name': 'plone_upgrade_needed',
+                   'required_params': [],
+                   'description': 'Returns "true" when Plone needs to be upgraded.',
+                   'request_method': 'GET'},
 
                   {'name': 'recook_resources',
                    'required_params': [],
@@ -449,3 +455,13 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
                 details='The profile "the.package:default" is unknown.'):
             self.api_request('POST', 'execute_profiles',
                              {'profiles:list': ['the.package:default']})
+
+    @browsing
+    def test_plone_upgrade_needed(self, browser):
+        self.api_request('GET', 'plone_upgrade_needed')
+        self.assertEquals('false', browser.contents.strip())
+
+        self.portal_setup.setLastVersionForProfile(_DEFAULT_PROFILE, '4')
+        transaction.commit()
+        self.api_request('GET', 'plone_upgrade_needed')
+        self.assertEquals('true', browser.contents.strip())


### PR DESCRIPTION
- adds a jsonapi endpoint "plone_upgrade_needed"
- adds a commaind "plone_upgrade_needed"
- both returning "true" when a Plone upgrade is needed
  according to portal_migration.