### PR TITLE
Add base_profile and target_version attributes.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -343,6 +343,20 @@ The ``UpgradeStep`` class has various helper functions:
     sure you did not change any security relevant permissions (only ``View`` needs
     ``reindex_security=True`` for default Plone).
 
+``self.base_profile``
+    The attribute ``base_profile`` contains the profile name of the upgraded
+    profile including the ``profile-`` prefix.
+    Example: ``u"profile-the.package:default"``.
+    This information is only available when using the
+    ``upgrade-step:directory`` directive.
+
+``self.target_version``
+    The attribute ``target_version`` contains the target version of the upgrade
+    step as a bytestring.
+    Example with upgrade step directory: ``"20110101000000"``.
+    This information is only available when using the
+    ``upgrade-step:directory`` directive.
+
 
 
 Progress logger

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.17.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Provide the attributes ``base_profile`` and ``target_version`` on
+  upgrade steps when using the ``upgrade-step:directory`` directive. [jone]
 
 
 1.17.0 (2016-01-22)

--- a/ftw/upgrade/directory/wrapper.py
+++ b/ftw/upgrade/directory/wrapper.py
@@ -7,7 +7,9 @@ from zope.interface import alsoProvides
 
 def wrap_upgrade_step(handler, upgrade_profile, base_profile, target_version):
     def upgrade_step_wrapper(portal_setup):
-        result = handler(portal_setup, upgrade_profile)
+        result = handler(portal_setup, upgrade_profile,
+                         base_profile=u'profile-' + base_profile,
+                         target_version=target_version)
 
         portal = getToolByName(portal_setup, 'portal_url').getPortalObject()
         recorder = getMultiAdapter((portal, base_profile),

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -35,10 +35,15 @@ class UpgradeStep(object):
         obj.__init__(*args, **kwargs)
         return obj()
 
-    def __init__(self, portal_setup, associated_profile=None):
+    def __init__(self, portal_setup,
+                 associated_profile=None,
+                 base_profile=None,
+                 target_version=None):
         self.portal_setup = portal_setup
         self.portal = self.getToolByName('portal_url').getPortalObject()
         self.associated_profile = associated_profile
+        self.base_profile = base_profile
+        self.target_version = target_version
 
     security.declarePrivate('__call__')
     def __call__(self):

--- a/ftw/upgrade/tests/test_directory_upgrade_steps.py
+++ b/ftw/upgrade/tests/test_directory_upgrade_steps.py
@@ -86,5 +86,30 @@ class TestDirectoryUpgradeSteps(UpgradeTestCase):
                 'Expected upgrade steps to be marked as installed'
                 ' after upgrading.')
 
+    def test_base_profile_and_target_version_are_provided(self):
+        self.portal.upgrade_infos = {}
+
+        class StoreUpgradeInfos(UpgradeStep):
+            def __call__(self):
+                self.portal.upgrade_infos.update({
+                    'base_profile': self.base_profile,
+                    'target_version': self.target_version,
+                })
+
+        self.package.with_profile(
+            Builder('genericsetup profile')
+            .with_upgrade(Builder('ftw upgrade step')
+                          .to(datetime(2011, 1, 1))
+                          .calling(StoreUpgradeInfos)))
+
+        with self.package_created():
+            self.install_profile('the.package:default')
+            self.assertEquals({}, self.portal.upgrade_infos)
+            self.install_profile_upgrades('the.package:default')
+            self.assertEquals(
+                {'base_profile': u'profile-the.package:default',
+                 'target_version': '20110101000000'},
+                self.portal.upgrade_infos)
+
     def get_action(self):
         return self.portal_actions.portal_tabs.get('test-action')

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -636,7 +636,6 @@ class TestUpgradeStep(UpgradeTestCase):
         self.assertEquals(['Anonymous'],
                           self.get_allowed_roles_and_users_for(folder))
 
-
     def test_update_workflow_security_expects_list_of_workflows(self):
         class Step(UpgradeStep):
             def __call__(self):
@@ -647,6 +646,23 @@ class TestUpgradeStep(UpgradeTestCase):
 
         self.assertEquals('"workflows" must be a list of workflow names.',
                           str(cm.exception))
+
+    def test_base_profile_and_target_version_are_stored_in_attribute(self):
+        result = {}
+
+        class Step(UpgradeStep):
+            def __call__(self):
+                result['base_profile'] = self.base_profile
+                result['target_version'] = self.target_version
+
+        Step(self.portal_setup,
+             base_profile='profile-ftw.upgrade:default',
+             target_version=1500)
+
+        self.assertEquals(
+            {'base_profile': 'profile-ftw.upgrade:default',
+             'target_version': 1500},
+            result)
 
     def set_workflow_chain(self, for_type, to_workflow):
         wftool = getToolByName(self.portal, 'portal_workflow')


### PR DESCRIPTION
Provide the attributes ``base_profile`` and ``target_version`` on upgrade steps when using the ``upgrade-step:directory`` directive.

This allows for better extension of the upgrade system.

/cc @4teamwork/gever 