### PR TITLE
Fix wrong default profile version in certain cases.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
 - Provide the attributes ``base_profile`` and ``target_version`` on
   upgrade steps when using the ``upgrade-step:directory`` directive. [jone]
 
+- Fix profile version when using `upgrade-step:directory` and
+  having old upgrade steps but no new ones. [jone]
+
 
 1.17.0 (2016-01-22)
 -------------------

--- a/ftw/upgrade/directory/zcml.py
+++ b/ftw/upgrade/directory/zcml.py
@@ -59,7 +59,7 @@ def upgrade_step_directory_action(profile, dottedname, path):
                 profile))
 
     _package, profilename = profile.split(':', 1)
-    last_version = str(10 ** 13)
+    last_version = ''.join(find_start_version(profile))
     for upgrade_info in scanner.scan():
         upgrade_profile_name = '{0}-upgrade-{1}'.format(
             profilename, upgrade_info['target-version'])


### PR DESCRIPTION
Fix profile version when using `upgrade-step:directory` and having classic upgrade steps but no new ones.

The problem was that when having classic upgrade steps, the generic setup profile version was set to 10000000000000 instead of to the target version of the last classic upgrade.

The problem only occured when:

- There were classic manual upgrade steps registered in ZCML.
- The `upgrade-step:directory` was used.
- There were not yet an `upgrade-step:directory` based upgrades.

/cc @4teamwork/gever @maethu 