### PR TITLE
Disable automatics CSRF protection for authorized jsonapi requests

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.18.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Disable automatic CSRF protection for authorized jsonapi requests. [jone]
 
 
 1.18.0 (2016-02-16)

--- a/ftw/upgrade/directory/recorder.py
+++ b/ftw/upgrade/directory/recorder.py
@@ -17,16 +17,23 @@ class UpgradeStepRecorder(object):
     def __init__(self, portal, profilename):
         self.portal = portal
         self.profile = self._normalize_profilename(profilename)
-        self.storage = self._get_profile_storage()
 
     def is_installed(self, target_version):
-        return bool(self.storage.get(target_version, False))
+        storage = self._get_profile_storage()
+        return storage and bool(storage.get(target_version, False))
 
     def mark_as_installed(self, target_version):
-        self.storage[target_version] = True
+        storage = self._get_profile_storage(create=True)
+        storage[target_version] = True
 
-    def _get_profile_storage(self):
+    def clear(self):
+        self._get_profile_storage(create=True).clear()
+
+    def _get_profile_storage(self, create=False):
         annotations = IAnnotations(self.portal)
+        if ANNOTATION_KEY not in annotations and not create:
+            return None
+
         if ANNOTATION_KEY not in annotations:
             annotations[ANNOTATION_KEY] = OOBTree()
 

--- a/ftw/upgrade/jsonapi/utils.py
+++ b/ftw/upgrade/jsonapi/utils.py
@@ -15,6 +15,7 @@ from ftw.upgrade.jsonapi.exceptions import UpgradeNotFoundWrapper
 from ftw.upgrade.utils import get_tempfile_authentication_directory
 from OFS.interfaces import IApplication
 from zExceptions import Unauthorized
+from zope.interface import alsoProvides
 from zope.security import checkPermission
 import inspect
 import json
@@ -22,6 +23,14 @@ import os
 import re
 import stat
 import transaction
+
+
+try:
+    from plone.protect.interfaces import IDisableCSRFProtection
+except ImportError:
+    DISABLE_CSRF = False
+else:
+    DISABLE_CSRF = True
 
 
 class ErrorHandling(object):
@@ -84,6 +93,9 @@ def action(method, rename_params={}):
 
                 if not checkPermission('cmf.ManagePortal', self.context):
                     raise Unauthorized()
+
+                if DISABLE_CSRF:
+                    alsoProvides(self.request, IDisableCSRFProtection)
 
                 params = extract_action_params(
                     func, self.request, rename_params)

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -68,14 +68,14 @@ class UpgradeTestCase(TestCase):
     def record_installed_upgrades(self, profile, *destinations):
         profile = re.sub('^profile-', '', profile)
         recorder = getMultiAdapter((self.portal, profile), IUpgradeStepRecorder)
-        recorder.storage.clear()
+        recorder.clear()
         map(recorder.mark_as_installed, destinations)
         transaction.commit()
 
     def clear_recorded_upgrades(self, profile):
         profile = re.sub('^profile-', '', profile)
         recorder = getMultiAdapter((self.portal, profile), IUpgradeStepRecorder)
-        recorder.storage.clear()
+        recorder.clear()
         transaction.commit()
 
     def asset(self, filename):

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -5,3 +5,13 @@ extends =
     versions.cfg
 
 package-name = ftw.upgrade
+
+
+[test]
+eggs += plone4.csrffixes
+
+
+[versions]
+plone.protect = 3.0.17
+plone.keyring = 3.0.1
+plone.locking = 2.0.9


### PR DESCRIPTION
Closes #105

This makes it possible to run upgrades with the `bin/upgrade` executable when having `plone.protect`'s CSRF auto protection enabled.

- Automatically disable CSRF-protection for all requests since we have our custom authentication mechanism in Place, working with a file on the server disk.
- Change recorder storage to not be initialized on read so that we do not create accidental writes when accessing the `manage-upgrades` view.

@deiferni may you take a look at this one?