### PR TITLE
Add option to force reinstall already installed profiles.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -932,6 +932,10 @@ ftw.upgrade (which was already installed):
     2016-01-05 13:09:48 INFO ftw.upgrade Ignoring already installed profile ftw.upgrade:default.
     Result: SUCCESS
 
+By default, already installed profiles are skipped.
+When supplying the ``force_reinstall=True`` request parameter,
+already installed profiles will be reinstalled.
+
 
 Upgrading Plone
 ~~~~~~~~~~~~~~~

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.18.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add option to force reinstall already installed profiles. [jone]
 
 
 1.18.1 (2016-03-09)

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -50,7 +50,8 @@ class Executioner(object):
         return self.install(data)
 
     security.declarePrivate('install_profiles_by_profile_ids')
-    def install_profiles_by_profile_ids(self, *profile_ids):
+    def install_profiles_by_profile_ids(self, *profile_ids, **options):
+        force_reinstall = options.get('force_reinstall', False)
         for profile_id in profile_ids:
             # Starting from GenericSetup 1.8.0 getLastVersionForProfile can
             # handle profile ids with or without 'profile-' prefix, but we need
@@ -60,7 +61,7 @@ class Executioner(object):
             if profile_id.startswith(prefix):
                 profile_id = profile_id[len(prefix):]
             installed = self.portal_setup.getLastVersionForProfile(profile_id)
-            if installed != 'unknown':
+            if installed != 'unknown' and not force_reinstall:
                 logger.info('Ignoring already installed profile %s.',
                             profile_id)
                 continue

--- a/ftw/upgrade/jsonapi/plonesite.py
+++ b/ftw/upgrade/jsonapi/plonesite.py
@@ -68,7 +68,7 @@ class PloneSiteAPI(APIView):
         return self._install_upgrades(*api_ids)
 
     @action('POST', rename_params={'profiles': 'profiles:list'})
-    def execute_profiles(self, profiles):
+    def execute_profiles(self, profiles, force_reinstall=False):
         """Executes a list of profiles, each identified by their ID.
         """
         self._require_up_to_date_plone_site()
@@ -79,7 +79,8 @@ class PloneSiteAPI(APIView):
             if not self.portal_setup.profileExists(profile):
                 raise ProfileNotFound(profile)
             profile_ids.append(profile)
-        return self._install_profiles(*profile_ids)
+        return self._install_profiles(*profile_ids,
+                                      force_reinstall=force_reinstall)
 
     @jsonify
     @action('POST')
@@ -155,11 +156,12 @@ class PloneSiteAPI(APIView):
         except Exception, exc:
             raise AbortTransactionWithStreamedResponse(exc)
 
-    def _install_profiles(self, *profile_ids):
+    def _install_profiles(self, *profile_ids, **options):
         executioner = IExecutioner(self.portal_setup)
         try:
             with ResponseLogger(self.request.RESPONSE, annotate_result=True):
-                executioner.install_profiles_by_profile_ids(*profile_ids)
+                executioner.install_profiles_by_profile_ids(
+                    *profile_ids, **options)
         except Exception, exc:
             raise AbortTransactionWithStreamedResponse(exc)
 

--- a/ftw/upgrade/tests/test_command_install.py
+++ b/ftw/upgrade/tests/test_command_install.py
@@ -120,3 +120,23 @@ class TestInstallCommand(CommandAndInstanceTestCase):
              u' ftw.upgrade:default.',
              u'Result: SUCCESS'],
             output.splitlines())
+
+    def test_force_install_already_installed_profiles(self):
+        self.setup_logging()
+        self.purge_log()
+        exitcode, output = self.upgrade_script(
+            'install -s plone --force --profiles ftw.upgrade:default')
+        self.assertEquals(
+            [u'ftw.upgrade: Installing profile ftw.upgrade:default.',
+             u'ftw.upgrade: Done installing profile ftw.upgrade:default.',
+             u'Result: SUCCESS'],
+            output.splitlines())
+
+    def test_force_option_is_meant_to_be_combined_with_profiles(self):
+        exitcode, output = self.upgrade_script(
+            'install -s plone --force --upgrades 20110101000000@the.package:default',
+            assert_exitcode=False)
+        self.assertEquals(3, exitcode)
+        self.assertEquals(
+            [u'ERROR: --force can only be used with --profiles.'],
+            output.splitlines())

--- a/ftw/upgrade/tests/test_command_install.py
+++ b/ftw/upgrade/tests/test_command_install.py
@@ -96,3 +96,27 @@ class TestInstallCommand(CommandAndInstanceTestCase):
             transaction.begin()  # sync transaction
             self.assertEquals(['https://foo.bar.com/baz/the-folder'],
                               self.layer['portal'].upgrade_info)
+
+    def test_install_profiles(self):
+        self.package.with_profile(Builder('genericsetup profile'))
+
+        self.setup_logging()
+        with self.package_created():
+            exitcode, output = self.upgrade_script(
+                'install -s plone --profiles the.package:default')
+            self.assertEquals(
+                [u'ftw.upgrade: Installing profile the.package:default.',
+                 u'ftw.upgrade: Done installing profile the.package:default.',
+                 u'Result: SUCCESS'],
+                output.splitlines())
+
+    def test_install_profiles_skipped_when_already_installed(self):
+        self.setup_logging()
+        self.purge_log()
+        exitcode, output = self.upgrade_script(
+            'install -s plone --profiles ftw.upgrade:default')
+        self.assertEquals(
+            [u'ftw.upgrade: Ignoring already installed profile'
+             u' ftw.upgrade:default.',
+             u'Result: SUCCESS'],
+            output.splitlines())

--- a/ftw/upgrade/tests/test_executioner.py
+++ b/ftw/upgrade/tests/test_executioner.py
@@ -144,3 +144,11 @@ class TestExecutioner(UpgradeTestCase):
             self.assertEquals(
                 ['Ignoring already installed profile the.package:default.'],
                 self.get_log())
+
+            self.purge_log()
+            executioner.install_profiles_by_profile_ids(profile_id,
+                                                        force_reinstall=True)
+            self.assertEquals(
+                ['Installing profile the.package:default.',
+                 'Done installing profile the.package:default.'],
+                self.get_log())

--- a/ftw/upgrade/tests/test_executioner.py
+++ b/ftw/upgrade/tests/test_executioner.py
@@ -123,3 +123,24 @@ class TestExecutioner(UpgradeTestCase):
             self.assertEquals('1.0', quickinstaller.get('the.package').getInstalledVersion())
             self.install_profile_upgrades('the.package:default')
             self.assertEquals('1.1', quickinstaller.get('the.package').getInstalledVersion())
+
+    def test_install_profiles_by_profile_ids(self):
+        self.package.with_profile(Builder('genericsetup profile')
+                                  .with_upgrade(Builder('plone upgrade step')
+                                                .upgrading('1000', to='1001')))
+
+        self.setup_logging()
+        profile_id = 'the.package:default'
+        with self.package_created():
+            executioner = queryAdapter(self.portal_setup, IExecutioner)
+            executioner.install_profiles_by_profile_ids(profile_id)
+            self.assertEquals(
+                ['Installing profile the.package:default.',
+                 'Done installing profile the.package:default.'],
+                self.get_log())
+
+            self.purge_log()
+            executioner.install_profiles_by_profile_ids(profile_id)
+            self.assertEquals(
+                ['Ignoring already installed profile the.package:default.'],
+                self.get_log())

--- a/ftw/upgrade/tests/test_jsonapi_plonesite.py
+++ b/ftw/upgrade/tests/test_jsonapi_plonesite.py
@@ -448,6 +448,27 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
             self.assertIn('Result: SUCCESS', browser.contents)
 
     @browsing
+    def test_execute_profiles_force_when_already_installed(self, browser):
+        self.package.with_profile(
+            Builder('genericsetup profile')
+            .with_upgrade(Builder('ftw upgrade step').to(datetime(2011, 1, 1))
+                          .named('The upgrade')))
+
+        with self.package_created():
+            self.portal_setup.runAllImportStepsFromProfile(
+                'profile-the.package:default')
+            transaction.commit()
+            self.api_request('POST', 'execute_profiles',
+                             {'profiles:list': ['the.package:default'],
+                              'force_reinstall': True})
+            self.assertNotIn(
+                'Ignoring already installed profile the.package:default.',
+                browser.contents)
+            self.assertIn('Done installing profile the.package:default.',
+                          browser.contents)
+            self.assertIn('Result: SUCCESS', browser.contents)
+
+    @browsing
     def test_execute_profiles_not_found(self, browser):
         with self.expect_api_error(
                 status=400,

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -10,10 +10,8 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.browserlayer.utils import register_layer
 from Products.CMFCore.utils import getToolByName
-from StringIO import StringIO
 from zope.interface import Interface
 from zope.interface.verify import verifyClass
-import logging
 
 
 class IMyProductLayer(Interface):
@@ -27,13 +25,7 @@ class TestUpgradeStep(UpgradeTestCase):
         super(TestUpgradeStep, self).setUp()
         self.portal = self.layer['portal']
         self.portal_setup = getToolByName(self.portal, 'portal_setup')
-
-        self.log = StringIO()
-        self.logger = logging.getLogger('ftw.upgrade')
-        self.logger.setLevel(logging.DEBUG)
-
-        handler = logging.StreamHandler(self.log)
-        self.logger.addHandler(handler)
+        self.setup_logging()
 
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
 
@@ -96,7 +88,7 @@ class TestUpgradeStep(UpgradeTestCase):
         self.assertEquals(['STARTING Log message',
                            '1 of 3 (33%): Log message',
                            'DONE Log message'],
-                          self.read_log())
+                          self.get_log())
 
     def test_objects_modifying_catalog_does_not_reduce_result_set(self):
         old_date = DateTime(2010, 1, 1)
@@ -698,7 +690,3 @@ class TestUpgradeStep(UpgradeTestCase):
         rid = catalog.getrid(path)
         index_data = catalog.getIndexDataForRID(rid)
         return index_data.get('allowedRolesAndUsers')
-
-    def read_log(self):
-        self.log.seek(0)
-        return self.log.read().strip().split('\n')


### PR DESCRIPTION
Add an option to force reinstalling already installed profiles.
The option is added on all layers (bin/upgrade command, jsonapi, executioner).

/cc @lukasgraf 
