### PR TITLE
Fix NoneType AttributeError with newest requests module.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.19.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix NoneType AttributeError with newest requests module. [jone]
 
 
 1.19.0 (2016-04-11)

--- a/ftw/upgrade/command/install.py
+++ b/ftw/upgrade/command/install.py
@@ -102,7 +102,10 @@ def install_command(args, requestor):
 
     with closing(requestor.POST(action, params=params,
                                 stream=True)) as response:
-        for line in response.iter_lines(chunk_size=30, decode_unicode=True):
+        for line in response.iter_lines(chunk_size=30):
+            if isinstance(line, str):
+                line = line.decode('utf-8')
+
             print line
 
     if line.strip() != 'Result: SUCCESS':

--- a/ftw/upgrade/command/plone_upgrade.py
+++ b/ftw/upgrade/command/plone_upgrade.py
@@ -44,7 +44,10 @@ def plone_upgrade_command(args, requestor):
 
     with closing(requestor.POST(action, params=params,
                                 stream=True)) as response:
-        for line in response.iter_lines(chunk_size=30, decode_unicode=True):
+        for line in response.iter_lines(chunk_size=30):
+            if isinstance(line, str):
+                line = line.decode('utf-8')
+
             print line
 
     line = line.strip()


### PR DESCRIPTION
With the newest "requests" (=2.11.0) streamed responses cannot be automatically decoded.
We now do this manually but always with utf-8, which should be quite a safe bet in our environment.

Closes #113 