### PR TITLE
Migration: do not migrate empty blobs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Migration: do not migrate empty blobs. [jone]
 
 
 2.0.3 (2016-09-27)

--- a/ftw/upgrade/migration.py
+++ b/ftw/upgrade/migration.py
@@ -419,8 +419,11 @@ class InplaceMigrator(object):
            and not IRichTextValue.providedBy(value):
             return recurse(field.fromUnicode(value))
 
-        if INamedField.providedBy(field) and value \
+        if INamedField.providedBy(field) and value is not None \
            and not isinstance(value, field._type):
+
+            if hasattr(value, 'get_size') and value.get_size() == 0:
+                return None
 
             source_is_blobby = IBlobWrapper.providedBy(value)
             target_is_blobby = INamedBlobFileField.providedBy(field) or \


### PR DESCRIPTION
When the blob was empty (e.g. no file uploaded) on the old object it was not converted and thus the old value was directly set on the new object, causing errors.
We now either migrate the blob or return None.