### PR TITLE
Upgrade step: profile / product methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -290,6 +290,9 @@ The ``UpgradeStep`` class has various helper functions:
     If a list step names is passed with ``steps`` (e.g. ['actions']),
     only those steps are installed. All steps are installed by default.
 
+``self.ensure_profile_installed(profileid)``
+    Install a generic setup profile only when it is not yet installed.
+
 ``self.install_upgrade_profile(steps=None)``
     Installs the generic setup profile associated with this upgrade step.
     Profile may be associated to upgrade steps by using either the

--- a/README.rst
+++ b/README.rst
@@ -295,6 +295,10 @@ The ``UpgradeStep`` class has various helper functions:
     Profile may be associated to upgrade steps by using either the
     ``upgrade-step:importProfile`` or the ``upgrade-step:directory`` directive.
 
+``self.is_profile_installed(profileid)``
+    Checks whether a generic setup profile is installed.
+    Respects product uninstallation via quickinstaller.
+
 ``self.is_product_installed(product_name)``
     Check whether a product is installed.
 

--- a/README.rst
+++ b/README.rst
@@ -295,6 +295,9 @@ The ``UpgradeStep`` class has various helper functions:
     Profile may be associated to upgrade steps by using either the
     ``upgrade-step:importProfile`` or the ``upgrade-step:directory`` directive.
 
+``self.is_product_installed(product_name)``
+    Check whether a product is installed.
+
 ``self.uninstall_product(product_name)``
     Uninstalls a product using the quick installer.
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,7 +2,7 @@ Changelog
 =========
 
 
-2.0.6 (unreleased)
+2.1.0 (unreleased)
 ------------------
 
 - Add upgrade step method ``ensure_profile_installed(profileid)``. [jone]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add upgrade step method ``is_product_installed(product_name)``. [jone]
 
 
 2.0.5 (2016-10-24)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.0.6 (unreleased)
 ------------------
 
+- Add upgrade step method ``is_profile_installed(profileid)``. [jone]
+
 - Add upgrade step method ``is_product_installed(product_name)``. [jone]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.0.6 (unreleased)
 ------------------
 
+- Add upgrade step method ``ensure_profile_installed(profileid)``. [jone]
+
 - Add upgrade step method ``is_profile_installed(profileid)``. [jone]
 
 - Add upgrade step method ``is_product_installed(product_name)``. [jone]

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -272,6 +272,13 @@ class UpgradeStep(object):
                                                run_dependencies=False,
                                                purge_old=False)
 
+    security.declarePrivate('ensure_profile_installed')
+    def ensure_profile_installed(self, profileid):
+        """Install a generic setup profile only when it is not yet installed.
+        """
+        if not self.is_profile_installed(profileid):
+            self.setup_install_profile(profileid)
+
     security.declarePrivate('install_upgrade_profile')
     def install_upgrade_profile(self, steps=None):
         """Installs the generic setup profile for this upgrade step.

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -280,6 +280,14 @@ class UpgradeStep(object):
 
         self.setup_install_profile(self.associated_profile, steps=steps)
 
+    security.declarePrivate('is_product_installed')
+    def is_product_installed(self, product_name):
+        """Check whether a product is installed.
+        """
+        quickinstaller = self.getToolByName('portal_quickinstaller')
+        return quickinstaller.isProductInstallable(product_name) and \
+            quickinstaller.isProductInstalled(product_name)
+
     security.declarePrivate('uninstall_product')
     def uninstall_product(self, product_name):
         """Uninstalls a product using the quick installer.

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -406,6 +406,36 @@ class TestUpgradeStep(UpgradeTestCase):
         with self.package_created():
             Step(self.portal_setup)
 
+    def test_ensure_profile_installed(self):
+        self.package.with_profile(Builder('genericsetup profile')
+                                  .with_fs_version('1111'))
+
+        testcase = self
+
+        class Step(UpgradeStep):
+            def __call__(self):
+                testcase.assertEquals('unknown', self.get_version())
+                self.ensure_profile_installed('profile-the.package:default')
+                testcase.assertEquals((u'1111',), self.get_version())
+                self.set_version((u'1000',))
+                testcase.assertEquals((u'1000',), self.get_version())
+                self.ensure_profile_installed('profile-the.package:default')
+                testcase.assertEquals(
+                    (u'1000',), self.get_version(),
+                    'Profile should not have been installed again because it'
+                    ' was already installed.')
+
+            def get_version(self):
+                return self.getToolByName('portal_setup').getLastVersionForProfile(
+                    'the.package:default')
+
+            def set_version(self, version):
+                return self.getToolByName('portal_setup').setLastVersionForProfile(
+                    'the.package:default', version)
+
+        with self.package_created():
+            Step(self.portal_setup)
+
     def test_install_upgrade_profile(self):
         class AddSiteProperty(UpgradeStep):
             def __call__(self):

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -434,6 +434,19 @@ class TestUpgradeStep(UpgradeTestCase):
         with self.assertRaises(NoAssociatedProfileError):
             Step(self.portal_setup)
 
+    def test_is_product_installed(self):
+        testcase = self
+
+        class Step(UpgradeStep):
+            def __call__(self):
+                testcase.assertTrue(self.is_product_installed(
+                    'CMFPlacefulWorkflow'))
+                self.uninstall_product('CMFPlacefulWorkflow')
+                testcase.assertFalse(self.is_product_installed(
+                    'CMFPlacefulWorkflow'))
+
+        Step(self.portal_setup)
+
     def test_uninstall_product(self):
         quickinstaller = getToolByName(self.portal, 'portal_quickinstaller')
         quickinstaller.installProduct('CMFPlacefulWorkflow')

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -447,6 +447,41 @@ class TestUpgradeStep(UpgradeTestCase):
 
         Step(self.portal_setup)
 
+    def test_is_profile_installed(self):
+        self.package.with_profile(Builder('genericsetup profile')
+                                  .with_fs_version('1000'))
+        testcase = self
+
+        class Step(UpgradeStep):
+            def __call__(self):
+                testcase.assertFalse(self.is_profile_installed(
+                    'profile-the.package:default'))
+                testcase.assertFalse(self.is_profile_installed(
+                    'the.package:default'))
+                self.setup_install_profile('profile-the.package:default')
+                testcase.assertTrue(self.is_profile_installed(
+                    'profile-the.package:default'))
+                testcase.assertTrue(self.is_profile_installed(
+                    'the.package:default'))
+
+        with self.package_created():
+            Step(self.portal_setup)
+
+    def test_is_profile_installed_respects_quickinstaller_uninstall(self):
+        testcase = self
+
+        class Step(UpgradeStep):
+            def __call__(self):
+                testcase.assertFalse(self.is_profile_installed(
+                    'Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow'))
+                self.setup_install_profile(
+                    'Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow')
+                testcase.assertTrue(self.is_profile_installed(
+                    'Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow'))
+                self.uninstall_product('Products.CMFPlacefulWorkflow')
+                testcase.assertFalse(self.is_profile_installed(
+                    'Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow'))
+
     def test_uninstall_product(self):
         quickinstaller = getToolByName(self.portal, 'portal_quickinstaller')
         quickinstaller.installProduct('CMFPlacefulWorkflow')

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '2.0.6.dev0'
+version = '2.1.0.dev0'
 
 tests_require = [
     'unittest2',


### PR DESCRIPTION
When adding a new dependency, I want to ensure in an upgrade step that this new dependency is installed.
If, however, the installation already has this dependency installed and probably configured / customized, I do not want to reinstall its Generic Setup profile because this may change configured settings back to defaults.
The new `ensure_profile_installed` does only install a Generic Setup profile when it is not yet installed. For example:

```python
from ftw.upgrade import UpgradeStep


class InstallFtwSimplelayout(UpgradeStep):
    """Install ftw.simplelayout.
    """

    def __call__(self):
        self.install_upgrade_profile()
        self.ensure_profile_installed('profile-ftw.simplelayout:default')
```

---

Since the `ensure_profile_installed` needs to check for profile / product installation, I also have added the methods `is_profile_installed` and `is_product_installed`.
(The `is_profile_installed` uses `is_product_installed` for checking whether a addon was uninstalled as quickinstaller product, which may lead to a profile version which is not `"unknown"` although it is considered uninstalled.)

---

``self.ensure_profile_installed(profileid)``
    Install a generic setup profile only when it is not yet installed.

``self.is_profile_installed(profileid)``
    Checks whether a generic setup profile is installed.
    Respects product uninstallation via quickinstaller.

``self.is_product_installed(product_name)``
    Check whether a product is installed.

