### PR TITLE
Fix support for GS import by tarball upload.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix support for GS import by tarball upload. [jone]
 
 
 2.1.0 (2016-12-06)

--- a/ftw/upgrade/directory/subscribers.py
+++ b/ftw/upgrade/directory/subscribers.py
@@ -7,6 +7,9 @@ import re
 
 
 def profile_installed(event):
+    if not event.profile_id:
+        return
+
     profile = re.sub('^profile-', '', event.profile_id)
     portal = getToolByName(event.tool, 'portal_url').getPortalObject()
     recorder = getMultiAdapter((portal, profile), IUpgradeStepRecorder)


### PR DESCRIPTION
When importing a tarball with Generic Setup the ftw.upgrade subscriber failed because the tarball was not bound to a profile.