### PR TITLE
Add method to remove a previously uninstalled portlet manager from the persistent registry.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add method to remove a previously uninstalled portlet manager from the
+  persistent registry.
+  [deiferni]
 
 
 2.1.1 (2016-12-13)

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -373,6 +373,8 @@ class UpgradeStep(object):
                                 if not layer.__name__ == iface_name])
         layer_subscribers[''] = remaining_layers
 
+        sm._utility_registrations.pop((ILocalBrowserLayerType, name))
+
         sm.utilities._p_changed = True
 
     security.declarePrivate('update_security')

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -586,6 +586,8 @@ class TestUpgradeStep(UpgradeTestCase):
         iface_name = 'IMyProductLayer'
         self.assertEqual(len([layer for layer in layer_subscribers['']
                               if layer.__name__ == iface_name]), 0)
+        self.assertNotIn((ILocalBrowserLayerType, 'my.product'),
+                         sm._utility_registrations)
 
 
     def test_update_security_removes_roles_unmanaged_by_workflow(self):

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -579,6 +579,7 @@ class TestUpgradeStep(UpgradeTestCase):
         self.assertFalse(IMyProductLayer in registered_layers())
         # Check it a bit more low level.
         sm = self.portal.getSiteManager()
+
         adapters = sm.utilities._adapters
         self.assertFalse('my.product' in adapters[0][ILocalBrowserLayerType])
         subscribers = sm.utilities._subscribers
@@ -588,6 +589,37 @@ class TestUpgradeStep(UpgradeTestCase):
                               if layer.__name__ == iface_name]), 0)
         self.assertNotIn((ILocalBrowserLayerType, 'my.product'),
                          sm._utility_registrations)
+
+    def test_remove_remove_broken_portlet_manager(self):
+        from plone.portlets.interfaces import IPortletManager
+        from plone.portlets.interfaces import IPortletManagerRenderer
+        from plone.portlets.manager import PortletManager
+        from zope.browser.interfaces import IBrowserView
+        from zope.publisher.interfaces.browser import IBrowserRequest
+
+        sm = self.portal.getSiteManager()
+        sm.registerUtility(component=PortletManager(),
+                           provided=IPortletManager,
+                           name='my.manager')
+
+        self.assertIsNotNone(sm.adapters.lookup(
+            [Interface, IBrowserRequest, IBrowserView],
+            IPortletManagerRenderer,
+            'my.manager'))
+        self.assertIsNotNone(sm.queryUtility(
+            IPortletManager, name='my.manager'))
+
+        class Step(UpgradeStep):
+            def __call__(self):
+                self.remove_broken_portlet_manager('my.manager')
+        Step(self.portal_setup)
+
+        self.assertIsNone(sm.adapters.lookup(
+            [Interface, IBrowserRequest, IBrowserView],
+            IPortletManagerRenderer,
+            'my.manager'))
+        self.assertIsNone(sm.queryUtility(
+            IPortletManager, name='my.manager'))
 
 
     def test_update_security_removes_roles_unmanaged_by_workflow(self):

--- a/ftw/upgrade/utils.py
+++ b/ftw/upgrade/utils.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from contextlib import contextmanager
 from copy import deepcopy
 from ftw.upgrade.exceptions import CyclicDependencies
 from path import Path
@@ -244,3 +245,28 @@ def get_tempfile_authentication_directory(directory=None):
         raise ValueError('{0} has an invalid owner.'.format(auth_directory))
 
     return auth_directory
+
+
+class StartsWithLogFilter(logging.Filter):
+    """Filter messages that start with criteria."""
+
+    def __init__(self, criteria):
+        self.criteria = criteria
+
+    def filter(self, record):
+        return not record.getMessage().startswith(self.criteria)
+
+
+@contextmanager
+def log_silencer(logger_name, criteria):
+    """Prevents messages that start with `criteria` from being logged to the
+    logger that is registered as `logger_name`.
+    """
+    log = logging.getLogger(logger_name)
+    filt = StartsWithLogFilter(criteria)
+    log.addFilter(filt)
+
+    try:
+        yield
+    finally:
+        log.removeFilter(filt)


### PR DESCRIPTION
This PR adds a method that allows to remove a portlet manager, that cannot be imported any more, from the persistent registry.

It also makes sure that utilities are really, really unregistered 😁 .