### PR TITLE
add upgrade-step:directory dependencies option.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -639,6 +639,37 @@ Setting up an upgrade directory
     </metadata>
 
 
+Declare upgrades soft dependencies
+-----------------------------
+
+When having optional dependencies (``extras_require``), we sometimes need to tell
+``ftw.upgrade`` that our optional dependency's upgrades needs to be installed
+before our upgrades are installed.
+
+We do that by declare a soft dependency in the ``upgrade-step:directory``
+directive.
+It is possible to declare multiple dependencies by separating them
+with whitespace.
+
+.. code:: xml
+
+    <configure
+        xmlns="http://namespaces.zope.org/zope"
+        xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
+        i18n_domain="my.package">
+
+        <include package="ftw.upgrade" file="meta.zcml" />
+
+        <upgrade-step:directory
+            profile="my.package:default"
+            directory="./upgrades"
+            soft_dependencies="other.package:default
+                               collective.fancy:default"
+            />
+
+    </configure>
+
+
 Creating an upgrade step
 ------------------------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 
 - Do not downgrade installed version when installing an orphan upgrade step. [jone]
 
+- Add "soft_dependencies" option to "upgrade-step:directory" directive. [jone]
+
 
 2.2.0 (2017-01-30)
 ------------------

--- a/ftw/upgrade/tests/builders.py
+++ b/ftw/upgrade/tests/builders.py
@@ -18,6 +18,7 @@ class UpgradeStepBuilder(object):
         self.code = None
         self.directories = []
         self.files = []
+        self.zcml_directory_options = None
 
     def to(self, destination):
         if hasattr(destination, 'strftime'):
@@ -58,6 +59,12 @@ class UpgradeStepBuilder(object):
         self.directories.append(relative_path)
         return self
 
+    def with_zcml_directory_options(self, **options):
+        """Set additional options in the upgrade-step:directory directive.
+        """
+        self.zcml_directory_options = options
+        return self
+
     def with_file(self, relative_path, contents, makedirs=False):
         """Create a file within this package.
         """
@@ -93,7 +100,8 @@ class UpgradeStepBuilder(object):
         zcml.include('ftw.upgrade', file='meta.zcml')
         zcml.with_node('upgrade-step:directory',
                        profile=self.profile_builder.profile_name,
-                       directory='.')
+                       directory='.',
+                       **(self.zcml_directory_options or {}))
         zcml._upgrade_step_declarations[self.profile_builder.name] = True
 
     def _create_upgrade(self):


### PR DESCRIPTION
The new "dependencies" option allows to declare Generic Setup profile dependencies which are only relevant when installing upgrade steps.
It influences the topological dependency sorting in the manage-upgrades view.

See the readme changes for more details.

FYI @lukasgraf 