### PR TITLE
do not downgrade installed versions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not downgrade installed version when installing an orphan upgrade step. [jone]
 
 
 2.2.0 (2017-01-30)

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -89,8 +89,11 @@ class Executioner(object):
             last_dest_version = self._do_upgrade(profileid, upgradeid) \
                 or last_dest_version
 
-        self.portal_setup.setLastVersionForProfile(
-            profileid, last_dest_version)
+        old_version = self.portal_setup.getLastVersionForProfile(
+            profileid)
+        if last_dest_version > old_version:
+            self.portal_setup.setLastVersionForProfile(
+                profileid, last_dest_version)
 
         self._set_quickinstaller_version(profileid)
 

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -87,6 +87,28 @@ class UpgradeTestCase(TestCase):
         recorder.clear()
         transaction.commit()
 
+    def assert_gathered_upgrades(self, expected, *args, **kwargs):
+        gatherer = queryAdapter(self.portal_setup, IUpgradeInformationGatherer)
+        result = gatherer.get_profiles(*args, **kwargs)
+        got = {}
+        for profile in result:
+            if profile['id'] not in expected:
+                continue
+
+            got_profile = dict((key, []) for key in expected[profile['id']].keys())
+            got[profile['id']] = got_profile
+
+            for upgrade in profile['upgrades']:
+                for key in got_profile.keys():
+                    if upgrade[key]:
+                        got_profile[key].append(upgrade['sdest'])
+
+        self.maxDiff = None
+        self.assertDictEqual(
+            expected, got,
+            'Unexpected gatherer result.\n\nPackages in result {0}:'.format(
+                map(lambda profile: profile['id'], result)))
+
     def asset(self, filename):
         return Path(__file__).dirname().joinpath('assets', filename).text()
 

--- a/ftw/upgrade/tests/test_gatherer.py
+++ b/ftw/upgrade/tests/test_gatherer.py
@@ -358,28 +358,6 @@ class TestUpgradeInformationGatherer(UpgradeTestCase):
         result = gatherer.get_profiles()
         return dict([(profile['id'], profile) for profile in result])
 
-    def assert_gathered_upgrades(self, expected, *args, **kwargs):
-        gatherer = queryAdapter(self.portal_setup, IUpgradeInformationGatherer)
-        result = gatherer.get_profiles(*args, **kwargs)
-        got = {}
-        for profile in result:
-            if profile['id'] not in expected:
-                continue
-
-            got_profile = dict((key, []) for key in expected[profile['id']].keys())
-            got[profile['id']] = got_profile
-
-            for upgrade in profile['upgrades']:
-                for key in got_profile.keys():
-                    if upgrade[key]:
-                        got_profile[key].append(upgrade['sdest'])
-
-        self.maxDiff = None
-        self.assertDictEqual(
-            expected, got,
-            'Unexpected gatherer result.\n\nPackages in result {0}:'.format(
-                map(lambda profile: profile['id'], result)))
-
     def assert_outdated_profiles(self, expected_profiles, ignore=()):
         gatherer = queryAdapter(self.portal_setup, IUpgradeInformationGatherer)
         result = gatherer.get_profiles()


### PR DESCRIPTION
When only an orphan upgrade step is installed, it might downgrade the installed version of its profile.

Solution:
Only set the version when it is higher than the current version.

Fixes #126