### PR TITLE
Avoid profile reinstall in upgrades.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- Avoid overriding customizations by reinstalling already installed
+  profiles while upgrading (Plone>=4.3.8). [jone]
+
 - InplaceMigrator: Preserve object position in parent. [lknoepfel]
 
 - Do not downgrade installed version when installing an orphan upgrade step. [jone]

--- a/ftw/upgrade/tests/test_migration.py
+++ b/ftw/upgrade/tests/test_migration.py
@@ -115,8 +115,13 @@ class TestInplaceMigrator(UpgradeTestCase):
                          folder.get_local_roles())
 
         self.maxDiff = None
-        self.assertDictEqual(old_catalog_indexdata,
-                             self.get_catalog_indexdata_for(folder))
+
+        new_catalog_indexdata = self.get_catalog_indexdata_for(folder)
+        # In Plone 4.3.7, the SearchableText changes here.
+        del old_catalog_indexdata['SearchableText']
+        del new_catalog_indexdata['SearchableText']
+
+        self.assertDictEqual(old_catalog_indexdata, new_catalog_indexdata)
 
     def test_migrate_dexterity_folder_to_dexterity(self):
         self.grant('Manager')

--- a/test-plone-4.3.7.cfg
+++ b/test-plone-4.3.7.cfg
@@ -1,0 +1,10 @@
+# The 4.3.7 test has an older Products.GenericSetup version (<=1.7),
+# which does not have the dependency_strategy option yet.
+# We need to support older versions as well as newer versions,
+# therefor we have a 4.3.7 test config.
+
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.7.cfg
+
+package-name = ftw.upgrade


### PR DESCRIPTION
Avoid coverriding customizations by reinstalling already installed profiles while upgrading (Plone>=4.3.8).

If an Upgrade in `A` installes the new dependency `B`, which depends on `C` but `C` was already installed and customized in `A` earlier, we should not reinstall `C` so that we can avoid lossing `A`'s customizations.

This is simply done by using the dependency strategy `DEPENDENCY_STRATEGY_NEW`, which is available in `Products.GenericSetup >= 1.8` (`Plone >= 4.3.8`).

Closes #125
FYI @buchi @lukasgraf 