### PR TITLE
InplaceMigrator: Preserve object position in parent.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- InplaceMigrator: Preserve object position in parent. [lknoepfel]
+
 - Do not downgrade installed version when installing an orphan upgrade step. [jone]
 
 - Add "soft_dependencies" option to "upgrade-step:directory" directive. [jone]

--- a/ftw/upgrade/migration.py
+++ b/ftw/upgrade/migration.py
@@ -260,6 +260,7 @@ class InplaceMigrator(object):
     def replace_in_parent(self, old_object, new_object):
         parent = aq_parent(aq_inner(old_object))
         new_object = aq_base(new_object)
+        position_in_parent = parent.getObjectPosition(old_object.id)
 
         parent._delOb(old_object.id)
         objects = [info for info in parent._objects
@@ -274,6 +275,8 @@ class InplaceMigrator(object):
         if hasattr(aq_base(parent), '_tree'):
             del parent._tree[new_object.id]
             parent._tree[new_object.id] = new_object
+
+        parent.moveObjectToPosition(new_object.id, position_in_parent)
 
         return parent._getOb(new_object.id)
 

--- a/ftw/upgrade/tests/test_migration.py
+++ b/ftw/upgrade/tests/test_migration.py
@@ -363,18 +363,22 @@ class TestInplaceMigrator(UpgradeTestCase):
     def test_migrate_object_position(self):
         self.grant('Manager')
         container = create(Builder('folder').titled('Container'))
-        create(Builder('folder').titled('One').within(container))
-        create(Builder('folder').titled('Two').within(container))
+        one = create(Builder('folder').titled('One').within(container))
+        two = create(Builder('folder').titled('Two').within(container))
+        three = create(Builder('folder').titled('Three').within(container))
 
-        self.assertEquals([0, 1], map(container.getObjectPosition, ('one', 'two')))
-        container.moveObjectsByDelta(['two'], -1)
-        self.assertEquals([1, 0], map(container.getObjectPosition, ('one', 'two')))
+        self.assertEquals([0, 1, 2], map(container.getObjectPosition, ('one', 'two', 'three')))
+        container.moveObjectsByDelta(['three'], -1)
+        self.assertEquals([0, 2, 1], map(container.getObjectPosition, ('one', 'two', 'three')))
 
         self.install_profile('plone.app.contenttypes:default')
         InplaceMigrator('Folder').migrate_object(container)
+        InplaceMigrator('Folder').migrate_object(three)
+        InplaceMigrator('Folder').migrate_object(two)
+        InplaceMigrator('Folder').migrate_object(one)
         container = self.portal.get('container')
 
-        self.assertEquals([1, 0], map(container.getObjectPosition, ('one', 'two')))
+        self.assertEquals([0, 2, 1], map(container.getObjectPosition, ('one', 'two', 'three')))
 
     def test_migrate_portlets(self):
         self.grant('Manager')


### PR DESCRIPTION
The migration of an object removes the old object from the parent and
appends the new one. This previously resulted in a new order which depends on the
order of the migration of the objects.