### PR TITLE
fix bug when setting versions after upgrading.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.3.1 (unreleased)
 ------------------
 
+- Fix bug causing that versions are not properly set after upgrading
+  when switching versioning system. [jone]
+
 - Avoid overriding customizations by reinstalling already installed
   profiles while upgrading (Plone>=4.3.8). [jone]
 

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -1,4 +1,5 @@
 from AccessControl.SecurityInfo import ClassSecurityInformation
+from distutils.version import LooseVersion
 from ftw.upgrade.interfaces import IExecutioner
 from ftw.upgrade.interfaces import IPostUpgrade
 from ftw.upgrade.interfaces import IUpgradeInformationGatherer
@@ -89,9 +90,11 @@ class Executioner(object):
             last_dest_version = self._do_upgrade(profileid, upgradeid) \
                 or last_dest_version
 
-        old_version = self.portal_setup.getLastVersionForProfile(
-            profileid)
-        if last_dest_version > old_version:
+        old_version = self.portal_setup.getLastVersionForProfile(profileid)
+        compareable = lambda v: LooseVersion('.'.join(v))
+
+        if old_version == 'unknown' or \
+           compareable(last_dest_version) > compareable(old_version):
             self.portal_setup.setLastVersionForProfile(
                 profileid, last_dest_version)
 


### PR DESCRIPTION
In the version 2.3.0 we have introduced a check that avoids downgrading when installing orphan upgrades.
Since the version comparison is made as string and not with parsing the version, it will cause wrong results when switching versioning systems (e.g. from 4020 to 20160101000000).
The effect will be that upgrades are proposed which should not be.