### PR TITLE
Restore compatibility with newest ftw.testbrowser.

### DIFF
--- a/ftw/upgrade/tests/test_jsonapi_plonesite.py
+++ b/ftw/upgrade/tests/test_jsonapi_plonesite.py
@@ -129,9 +129,9 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
     def test_get_profile_requires_GET(self, browser):
         with self.expect_api_error(status=405,
                                    message='Method Not Allowed',
-                                   details='Action requires GET') as cm:
+                                   details='Action requires GET'):
             self.api_request('POST', 'get_profile', {'profileid': 'the.package:default'})
-        self.assertEquals('GET', cm['headers'].get('allow'))
+        self.assertEquals('GET', browser.headers.get('allow'))
 
     @browsing
     def test_get_unkown_profile_returns_error(self, browser):
@@ -353,9 +353,9 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
     def test_execute_upgrades_requires_POST(self, browser):
         with self.expect_api_error(status=405,
                                    message='Method Not Allowed',
-                                   details='Action requires POST') as cm:
+                                   details='Action requires POST'):
             self.api_request('GET', 'execute_upgrades', {'upgrades:list': 'foo@bar:default'})
-        self.assertEquals('POST', cm['headers'].get('allow'))
+        self.assertEquals('POST', browser.headers.get('allow'))
 
     @browsing
     def test_execute_upgrades_not_allowed_when_plone_outdated(self, browser):

--- a/ftw/upgrade/tests/test_jsonapi_zopeapp.py
+++ b/ftw/upgrade/tests/test_jsonapi_zopeapp.py
@@ -58,10 +58,10 @@ class TestZopeAppJsonApi(JsonApiTestCase):
     def test_requiring_wrong_api_version_by_url(self, browser):
         with self.expect_api_error(status=404,
                                    message='Wrong API version',
-                                   details='The API version "v100" is not available.') as cm:
+                                   details='The API version "v100" is not available.'):
             self.api_request('GET', 'v100/list_plone_sites', context=self.app)
 
-        self.assertTrue(cm['body'].endswith('\n'),
+        self.assertTrue(browser.contents.endswith('\n'),
                         'There should always be a trailing newline.')
 
     @browsing


### PR DESCRIPTION
The newest ftw.testbrowser has changed regarding HTTP error exceptions.
The new browser.expect_api_error context manager makes it easier to test ftw.upgrade's api errors.