### PR TITLE
Log current item in ProcessLogger if logger exits unexpectedly

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.3.2 (unreleased)
 ------------------
 
+- Escape < and > in browser logger. [lknoepfel]
+
 - Log current item in ProcessLogger if logger exits unexpectedly. [lknoepfel]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Log current item in ProcessLogger if logger exits unexpectedly. [lknoepfel]
 
 
 2.3.1 (2017-02-15)

--- a/ftw/upgrade/browser/manage.py
+++ b/ftw/upgrade/browser/manage.py
@@ -55,6 +55,8 @@ class ResponseLogger(object):
         if isinstance(line, unicode):
             line = line.encode('utf8')
 
+        line = line.replace('<', '&lt;').replace('>', '&gt;')
+
         self.response.write(line)
         self.response.flush()
 

--- a/ftw/upgrade/progresslogger.py
+++ b/ftw/upgrade/progresslogger.py
@@ -24,6 +24,7 @@ class ProgressLogger(object):
         self.timeout = timeout
         self._timestamp = None
         self._counter = 0
+        self._current_item = None
 
     security.declarePrivate('__enter__')
     def __enter__(self):
@@ -36,10 +37,16 @@ class ProgressLogger(object):
             self.logger.info('DONE %s' % self.message)
 
         else:
-            self.logger.error('FAILED %s (%s: %s)' % (
+            if self._current_item is not None:
+                current_step = repr(self._current_item)
+            else:
+                current_step = 'item nr. %d' % self._counter
+
+            self.logger.error('FAILED %s (%s: %s) at %s' % (
                     self.message,
                     str(exc_type.__name__),
-                    str(exc_value)))
+                    str(exc_value),
+                    current_step))
 
     security.declarePrivate('__call__')
     def __call__(self):
@@ -58,6 +65,7 @@ class ProgressLogger(object):
     def __iter__(self):
         with self as step:
             for item in self.iterable:
+                self._current_item = item
                 yield item
                 step()
 

--- a/ftw/upgrade/tests/test_manage_view.py
+++ b/ftw/upgrade/tests/test_manage_view.py
@@ -26,6 +26,17 @@ class TestResponseLogger(TestCase):
             ['foo', u'bar'],
             response.read().strip().split('\n'))
 
+    def test_logged_tags_get_escaped(self):
+        response = StringIO()
+
+        with ResponseLogger(response):
+            logging.error('ERROR: Something at <TextBlock at /bla/blub>')
+
+        response.seek(0)
+        self.assertEqual(
+            ['ERROR: Something at &lt;TextBlock at /bla/blub&gt;'],
+            response.read().strip().split('\n'))
+
     def test_logging_exceptions(self):
         response = StringIO()
 

--- a/ftw/upgrade/tests/test_progresslogger.py
+++ b/ftw/upgrade/tests/test_progresslogger.py
@@ -52,7 +52,7 @@ class TestProgressLogger(TestCase):
                           '1 of 5 (20%): Bar',
                           '2 of 5 (40%): Bar',
                           '3 of 5 (60%): Bar',
-                          'FAILED Bar (ValueError: baz)'],
+                          'FAILED Bar (ValueError: baz) at item nr. 3'],
                          self.read_log())
 
     def test_accepts_iterable_object(self):
@@ -83,3 +83,16 @@ class TestProgressLogger(TestCase):
         self.assertEqual(
             items, result,
             'Iterating over the progresslogger yields the original items.')
+
+    def test_current_item_is_printed_when_logger_exits_unexpectedly(self):
+        items = range(5)
+
+        with self.assertRaises(ValueError):
+            for item in ProgressLogger('Foo', items, logger=self.logger):
+                if item == 4:
+                    raise ValueError('baz')
+
+        self.assertEquals(['STARTING Foo',
+                           '1 of 5 (20%): Foo',
+                           'FAILED Foo (GeneratorExit: ) at 4'],
+                          self.read_log())


### PR DESCRIPTION
Fixes https://github.com/4teamwork/ftw.upgrade/issues/135

If the `ProcessLogger` is used as an iterator and there is an exception, the last item will be logged. If the `ProcessLogger` is used by manually calling it after each step the current iteration number is logged since the current item can not reliably be determined.

![screen shot 2017-05-16 at 16 16 25](https://cloud.githubusercontent.com/assets/1375745/26110655/3fe5051e-3a53-11e7-924a-c84a6fad87be.png)

There is a display bug in the ajax upgrade output in the browser. Tags are not escaped which causes `repr` logs to disappear.
![screen shot 2017-05-16 at 16 20 19](https://cloud.githubusercontent.com/assets/1375745/26110796/a3751d26-3a53-11e7-84f1-9c083ed84401.png)

This is fixed in the second commit.
![screen shot 2017-05-16 at 16 09 42](https://cloud.githubusercontent.com/assets/1375745/26110843/c3d99ee8-3a53-11e7-8e0d-f8f9c4dbc16d.png)
