### PR TITLE
Log collective.indexing progress while upgrading.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Log (re/un)-indexing progress if collective.indexing is installed. [deiferni]
 
 
 2.5.0 (2017-06-07)

--- a/ftw/upgrade/configure.zcml
+++ b/ftw/upgrade/configure.zcml
@@ -32,4 +32,12 @@
         handler=".directory.subscribers.profile_installed"
         />
 
+    <configure zcml:condition="installed collective.indexing">
+        <utility
+             provides="collective.indexing.interfaces.IIndexQueueProcessor"
+             name="ftw-upgrade-logging"
+             factory=".indexing.LoggingQueueProcessor"
+             />
+    </configure>
+
 </configure>

--- a/ftw/upgrade/configure.zcml
+++ b/ftw/upgrade/configure.zcml
@@ -40,4 +40,12 @@
              />
     </configure>
 
+    <configure zcml:condition="have plone-5">
+        <utility
+             provides="Products.CMFCore.interfaces.IIndexQueueProcessor"
+             name="ftw-upgrade-logging"
+             factory=".indexing.LoggingQueueProcessor"
+             />
+    </configure>
+
 </configure>

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -1,5 +1,6 @@
 from AccessControl.SecurityInfo import ClassSecurityInformation
 from distutils.version import LooseVersion
+from ftw.upgrade.interfaces import IDuringUpgrade
 from ftw.upgrade.interfaces import IExecutioner
 from ftw.upgrade.interfaces import IPostUpgrade
 from ftw.upgrade.interfaces import IUpgradeInformationGatherer
@@ -12,6 +13,7 @@ from Products.GenericSetup.interfaces import ISetupTool
 from Products.GenericSetup.upgrade import _upgrade_registry
 from zope.component import adapts
 from zope.component import getAdapters
+from zope.interface import alsoProvides
 from zope.interface import implements
 import logging
 import time
@@ -29,6 +31,7 @@ class Executioner(object):
 
     def __init__(self, portal_setup):
         self.portal_setup = portal_setup
+        alsoProvides(portal_setup.REQUEST, IDuringUpgrade)
 
     security.declarePrivate('install')
     def install(self, data):

--- a/ftw/upgrade/indexing.py
+++ b/ftw/upgrade/indexing.py
@@ -3,10 +3,12 @@ import pkg_resources
 HAS_INDEXING = False
 
 try:
+    # Plone 5
     from Products.CMFCore.indexing import processQueue
     from Products.CMFCore.indexing import getQueue
 except ImportError:
     try:
+        # Plone 4 with collective.indexing
         pkg_resources.get_distribution('collective.indexing')
     except pkg_resources.DistributionNotFound:
         def processQueue():
@@ -59,7 +61,7 @@ if HAS_INDEXING:
                 return
             self.logger()
 
-        def reindex(self, obj, attributes):
+        def reindex(self, obj, attributes, update_metadata=False):
             if not self.should_log:
                 return
             self.logger()

--- a/ftw/upgrade/indexing.py
+++ b/ftw/upgrade/indexing.py
@@ -1,16 +1,26 @@
 import pkg_resources
 
+HAS_INDEXING = False
 
 try:
-    pkg_resources.get_distribution('collective.indexing')
-except pkg_resources.DistributionNotFound:
-    HAS_INDEXING = False
+    from Products.CMFCore.indexing import processQueue
+    from Products.CMFCore.indexing import getQueue
+except ImportError:
+    try:
+        pkg_resources.get_distribution('collective.indexing')
+    except pkg_resources.DistributionNotFound:
+        def processQueue():
+            # Plone 4 without collective.indexing
+            pass
+    else:
+        from collective.indexing.queue import getQueue
+        from collective.indexing.queue import processQueue
+        HAS_INDEXING = True
 else:
     HAS_INDEXING = True
 
 
 if HAS_INDEXING:
-    from collective.indexing.queue import getQueue
     from ftw.upgrade.interfaces import IDuringUpgrade
     from ftw.upgrade.progresslogger import ProgressLogger
     from zope.globalrequest import getRequest

--- a/ftw/upgrade/indexing.py
+++ b/ftw/upgrade/indexing.py
@@ -1,0 +1,60 @@
+import pkg_resources
+
+
+try:
+    pkg_resources.get_distribution('collective.indexing')
+except pkg_resources.DistributionNotFound:
+    HAS_INDEXING = False
+else:
+    HAS_INDEXING = True
+
+
+if HAS_INDEXING:
+    from collective.indexing.queue import getQueue
+    from ftw.upgrade.interfaces import IDuringUpgrade
+    from ftw.upgrade.progresslogger import ProgressLogger
+    from zope.globalrequest import getRequest
+
+    class LoggingQueueProcessor(object):
+        """Queue processor to log collective.indexing progress.
+
+        A queue processor is used whenever a collective.indexing queue is
+        processed, i.e. when collective.indexing indexes, reindexes or
+        unindexes objects in the queue. This may happen several times while
+        executing upgrades (e.g. every time when executing a catalog-query).
+
+        For larger deployments with a lot of objects that process may take a
+        while, thus we display a progress bar while reindexing.
+        """
+        should_log = False
+
+        def begin(self):
+            self.should_log = IDuringUpgrade.providedBy(getRequest())
+            if not self.should_log:
+                return
+
+            indexing_queue_length = getQueue().length()
+            self.logger = ProgressLogger(
+                'Collective indexing: processing queue',
+                indexing_queue_length)
+
+        def commit(self):
+            pass
+
+        def abort(self):
+            pass
+
+        def index(self, obj, attributes):
+            if not self.should_log:
+                return
+            self.logger()
+
+        def reindex(self, obj, attributes):
+            if not self.should_log:
+                return
+            self.logger()
+
+        def unindex(self, obj):
+            if not self.should_log:
+                return
+            self.logger()

--- a/ftw/upgrade/indexing.py
+++ b/ftw/upgrade/indexing.py
@@ -47,7 +47,7 @@ if HAS_INDEXING:
 
             indexing_queue_length = getQueue().length()
             self.logger = ProgressLogger(
-                'Collective indexing: processing queue',
+                'Processing indexing queue',
                 indexing_queue_length)
 
         def commit(self):

--- a/ftw/upgrade/interfaces.py
+++ b/ftw/upgrade/interfaces.py
@@ -12,6 +12,10 @@ class IUpgradeLayer(Interface):
     """
 
 
+class IDuringUpgrade(Interface):
+    """Request layer to indicate that upgrades are currently executed."""
+
+
 class IClassMigratedEvent(IObjectEvent):
     """Fired after the class of an object is migrated.
 

--- a/ftw/upgrade/testing.py
+++ b/ftw/upgrade/testing.py
@@ -52,6 +52,17 @@ class UpgradeLayer(PloneSandboxLayer):
 
         z2.installProduct(app, 'Products.CMFPlacefulWorkflow')
 
+        try:
+            # Plone 4 with collective.indexing
+            pkg_resources.get_distribution('collective.indexing')
+        except pkg_resources.DistributionNotFound:
+            pass
+        else:
+            import collective.indexing
+            xmlconfig.file('configure.zcml', collective.indexing,
+                           context=configurationContext)
+            z2.installProduct(app, 'collective.indexing')
+
         manage_addVirtualHostMonster(app, 'virtual_hosting')
 
     def setUpPloneSite(self, portal):

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -3,6 +3,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browser
 from ftw.upgrade.directory import scaffold
+from ftw.upgrade.indexing import processQueue
 from ftw.upgrade.interfaces import IExecutioner
 from ftw.upgrade.interfaces import IUpgradeInformationGatherer
 from ftw.upgrade.interfaces import IUpgradeStepRecorder
@@ -29,14 +30,6 @@ import os
 import re
 import transaction
 import urllib
-
-
-try:
-    from Products.CMFCore.indexing import processQueue
-except ImportError:
-    def processQueue():
-        # Plone 4
-        pass
 
 
 class UpgradeTestCase(TestCase):

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -4,6 +4,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.upgrade import UpgradeStep
 from ftw.upgrade.exceptions import NoAssociatedProfileError
+from ftw.upgrade.indexing import processQueue
 from ftw.upgrade.interfaces import IUpgradeStep
 from ftw.upgrade.tests.base import UpgradeTestCase
 from plone.app.testing import setRoles
@@ -15,13 +16,6 @@ from unittest2 import skipIf
 from zope.interface import Interface
 from zope.interface.verify import verifyClass
 import pkg_resources
-
-try:
-    from Products.CMFCore.indexing import processQueue
-except ImportError:
-    def processQueue():
-        # Plone 4
-        pass
 
 
 class IMyProductLayer(Interface):

--- a/test-plone-4.3.x-with-collective.indexing.cfg
+++ b/test-plone-4.3.x-with-collective.indexing.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    test-plone-4.3.x.cfg
+
+[test]
+eggs += collective.indexing


### PR DESCRIPTION
This PR contains an alternative strategy to #14, instead of disabling `collective.indexing` while upgrading we log the reindex progress.

The PR adds an `IIndexQueueProcessor`-utility for `collective.indexing`. The new `LoggingQueueProcessor` utility logs (only during upgrades) whenever `collective.indexing` is processing its queue. This is especially helpful since reindexing may take quite a while. Before the upgrade would just hang without logging, which could be quite irritating for the poor person executing an upgrade on a deployment with a lot of content. With this PR it will output the following:

![screen shot 2017-05-24 at 16 56 26](https://cloud.githubusercontent.com/assets/736583/26412492/3a9ceb56-40a9-11e7-96b0-994082919022.png)

The utility will be registered all the time, but care is taken to only log while upgrading. I thought that this would be the better approach than attempting to dynamically register/unregister the utility.

Also there is a separate test config file that adds a dependency `collective.indexing` and tests with plone 4.
