### PR TITLE
Bump plone.protect to 3.0.19 in test-plone-4.3.x.cfg to fix tests

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -10,4 +10,4 @@ eggs += plone4.csrffixes
 
 
 [versions]
-plone.protect = 3.0.17
+plone.protect = 3.0.19


### PR DESCRIPTION
Test failure in question:
https://ci.4teamwork.ch/builds/90213/tasks/131576#bottom

Since we updated to the **latest Plone 4.3.x KGS** for test buildouts in 4teamwork/ftw-buildouts#83 we get the a more recent version of `plone4.csrffixes` (`1.1` instead of `1.0`).

Since `plone4.csrffixes == 1.1` now contains a [version constraint on `plone.protect >= 3.0.19`](), we need to bump it here.

@jone should we potentially also pin those other version contraints (`plone.keyring` and `plone.locking` here, even though they currently work?) 