### PR TITLE
Add multi user support for upgrade command.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support using ``bin/upgrade`` by another user than the Zope server
+  with less strict security checks.[jone]
 
 
 2.6.1 (2017-06-28)

--- a/ftw/upgrade/tests/test_utils.py
+++ b/ftw/upgrade/tests/test_utils.py
@@ -278,12 +278,6 @@ class TestGetTempfileAuthenticationDirectory(TestCase):
         tmpdir.chmod(tmpdir.stat().st_mode | stat.S_ISGID)
         get_tempfile_authentication_directory(self.buildoutdir)
 
-    def test_detects_unwanted_group_permissions(self):
-        tmpdir = get_tempfile_authentication_directory(self.buildoutdir)
-        tmpdir.chmod(tmpdir.stat().st_mode | stat.S_IRGRP)
-        with self.assertRaises(ValueError):
-            get_tempfile_authentication_directory(self.buildoutdir)
-
     def test_detects_unwanted_others_permissions(self):
         tmpdir = get_tempfile_authentication_directory(self.buildoutdir)
         tmpdir.chmod(tmpdir.stat().st_mode | stat.S_IROTH)

--- a/ftw/upgrade/utils.py
+++ b/ftw/upgrade/utils.py
@@ -7,7 +7,6 @@ from Products.GenericSetup.interfaces import IProfile
 from Products.GenericSetup.registry import GlobalRegistryStorage
 import logging
 import math
-import os
 import re
 import stat
 import tarjan.tc
@@ -234,14 +233,12 @@ def get_tempfile_authentication_directory(directory=None):
 
     auth_directory = directory.joinpath('var', 'ftw.upgrade-authentication')
     if not auth_directory.isdir():
-        auth_directory.mkdir(mode=0700)
+        auth_directory.mkdir(mode=0770)
 
-    # Verify that groups and others do not have any permissions on this
-    # directory, while the owner has rwx.
-    if (stat.S_IMODE(auth_directory.stat().st_mode) & 0777) != 0700:
-        raise ValueError('{0} has invalid mode.'.format(auth_directory))
-    if auth_directory.stat().st_uid != os.getuid():
-        raise ValueError('{0} has an invalid owner.'.format(auth_directory))
+    # Verify that "others" do not have any permissions on this directory.
+    if auth_directory.stat().st_mode & stat.S_IRWXO:
+        raise ValueError('{0} has invalid mode: "others" should not have '
+                         'any permissions'.format(auth_directory))
 
     return auth_directory
 


### PR DESCRIPTION
Support using ``bin/upgrade`` by another user than the Zope server
with less strict security checks.

- The owner of the token file is no longer verified.
- The token directory may be writeable by the owner group.

We assume that the `tmp` directory within the buildout can only be
accessed by trusted users.