### PR TITLE
Fix tempfile authentication when created by different user.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix tempfile authentication when created by different user. [jone]
 
 
 2.7.0 (2017-06-28)

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -66,6 +66,9 @@ class TempfileAuth(AuthBase):
             dir=directory)
         self.authfile.write(self.authhash)
         self.authfile.flush()
+        # Make sure the file is readable by the group, so that the service
+        # user running Zope can read it even when it is not the creator.
+        Path(self.authfile.name).chmod(0640)
 
     def _get_temp_directory(self):
         relative_to = self.relative_to or sys.argv[0]

--- a/ftw/upgrade/jsonapi/utils.py
+++ b/ftw/upgrade/jsonapi/utils.py
@@ -215,11 +215,9 @@ def validate_tempfile_authentication_header_value(header_value):
     if not filepath.isfile():
         raise ValueError('tempfile auth: tempfile does not exist.')
 
-    if stat.S_IMODE(filepath.stat().st_mode) != 0600:
-        raise ValueError('tempfile auth: tempfile has invalid mode.')
-
-    if filepath.stat().st_uid != os.getuid():
-        raise ValueError('tempfile auth: tempfile has invalid owner.')
+    # Verify that "others" do not have any permissions on this file.
+    if filepath.stat().st_mode & stat.S_IRWXO:
+        raise ValueError('tempfile auth: tempfile is accesible by "others".')
 
     if filepath.getsize() != 64:
         raise ValueError('tempfile auth: tempfile size is invalid.')


### PR DESCRIPTION
In order to support having a specific service user, which runs zope but does not do any other things, such as deploying, we need to support different users using `bin/upgrade` and running zope.
In order to do that we must create the authentication files with a mod so that the group can read it, assuming that the maintenance user and the service user have a shared primary group.