### PR TITLE
Fix encoding issues in ASCII terminals.

### DIFF
--- a/ftw/upgrade/command/install.py
+++ b/ftw/upgrade/command/install.py
@@ -103,8 +103,8 @@ def install_command(args, requestor):
     with closing(requestor.POST(action, params=params,
                                 stream=True)) as response:
         for line in response.iter_lines(chunk_size=30):
-            if isinstance(line, str):
-                line = line.decode('utf-8')
+            if isinstance(line, unicode):
+                line = line.encode('utf-8')
 
             print line
 

--- a/ftw/upgrade/command/plone_upgrade.py
+++ b/ftw/upgrade/command/plone_upgrade.py
@@ -45,8 +45,8 @@ def plone_upgrade_command(args, requestor):
     with closing(requestor.POST(action, params=params,
                                 stream=True)) as response:
         for line in response.iter_lines(chunk_size=30):
-            if isinstance(line, str):
-                line = line.decode('utf-8')
+            if isinstance(line, unicode):
+                line = line.encode('utf-8')
 
             print line
 


### PR DESCRIPTION
When bin/upgrade is ran in a terminal with LC_ALL=C, printed unicodes will be converted to the terminal encoding (ASCII). Since umlauts are not part of ASCII it will fail.

By already encoding unicodes to bytestrings we can awoid that print will convert the strings. If the terminal really cannot print those characters it will display placeholders instead.

Fixes #141