### PR TITLE
Fix memory leak.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -339,7 +339,7 @@ The ``UpgradeStep`` class has various helper functions:
     (``allowedRolesAndUsers``). This speeds up the update but should only be disabled
     when there are no changes for the ``View`` permission.
 
-``self.update_workflow_security(workflow_names, reindex_security=True)``
+``self.update_workflow_security(workflow_names, reindex_security=True, savepoints=1000)``
     Update all objects which have one of a list of workflows.
     This is useful when updating a bunch of workflows and you want to make sure
     that the object security is updated properly.
@@ -350,6 +350,10 @@ The ``UpgradeStep`` class has various helper functions:
     For speeding up you can pass ``reindex_security=False``, but you need to make
     sure you did not change any security relevant permissions (only ``View`` needs
     ``reindex_security=True`` for default Plone).
+
+    By default, transaction savepoints are created every 1000th object. This prevents
+    exaggerated memory consumption when creating large transactions. If your server has
+    enough memory, you may turn savepoints off by passing ``savepoints=None``.
 
 ``self.base_profile``
     The attribute ``base_profile`` contains the profile name of the upgraded

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use a SavepointIterator in the WorkflowSecurityUpdater in order not to exceed
+  memory. [mbaechtold]
 
 
 2.8.1 (2017-10-13)

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -442,10 +442,12 @@ class UpgradeStep(object):
         return update_security_for(obj, reindex_security=reindex_security)
 
     security.declarePrivate('update_workflow_security')
-    def update_workflow_security(self, workflow_names, reindex_security=True):
+    def update_workflow_security(self, workflow_names, reindex_security=True,
+                                 savepoints=1000):
         """Updates the object security of all objects with one of the
         passed workflows.
         `workflows` is expected to be a list of workflow names.
+        If `savepoints` is None, no savepoints will be created.
         """
 
         if getattr(workflow_names, '__iter__', None) is None or \
@@ -455,4 +457,5 @@ class UpgradeStep(object):
 
         from ftw.upgrade.workflow import WorkflowSecurityUpdater
         updater = WorkflowSecurityUpdater()
-        updater.update(workflow_names, reindex_security=reindex_security)
+        updater.update(workflow_names, reindex_security=reindex_security,
+                       savepoints=savepoints)

--- a/ftw/upgrade/workflow.py
+++ b/ftw/upgrade/workflow.py
@@ -2,6 +2,7 @@ from DateTime import DateTime
 from Products.CMFCore.utils import getToolByName
 from ftw.upgrade import ProgressLogger
 from ftw.upgrade.helpers import update_security_for
+from ftw.upgrade.utils import SavepointIterator
 from ftw.upgrade.utils import SizedGenerator
 from zope.component.hooks import getSite
 import logging
@@ -151,9 +152,10 @@ class WorkflowChainUpdater(object):
 
 class WorkflowSecurityUpdater(object):
 
-    def update(self, changed_workflows, reindex_security=True):
+    def update(self, changed_workflows, reindex_security=True, savepoints=1000):
         types = self.get_suspected_types(changed_workflows)
-        for obj in self.lookup_objects(types):
+        objects = SavepointIterator.build(self.lookup_objects(types), savepoints)
+        for obj in objects:
             if self.obj_has_workflow(obj, changed_workflows):
                 update_security_for(obj, reindex_security=reindex_security)
 


### PR DESCRIPTION
Use a `SavepointIterator` in the `WorkflowSecurityUpdater` in order not to exceed memory.