### PR TITLE
Reduce memory footprint in SavepointIterator by garbage collecting connection cache.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1188,6 +1188,23 @@ Registration in ZCML:
     </configure>
 
 
+Memory optimization while running upgrades
+==========================================
+
+Zope is optimized for executing many smaller requests.
+The ZODB pickle cache keeps objects in the memory, so that they can be used for the next
+request.
+
+Running a large upgrade is a long-running request though, increasing the chance of a
+memory problem.
+
+``ftw.upgrade`` tries to optimize the memory usage by creating savepoints and triggering
+the pickle cache garbage collector.
+
+In order for this to work properly you should configure your ZODB cache sizes correctly
+(`zodb-cache-size-bytes` or `zodb-cache-size`).
+
+
 
 Links
 =====

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2.8.2 (unreleased)
 ------------------
 
+- Reduce memory footprint in SavepointIterator by minimizing connection cache. [jone]
 - Use a SavepointIterator in the WorkflowSecurityUpdater in order not to exceed
   memory. [mbaechtold]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.8.2 (unreleased)
 ------------------
 
-- Reduce memory footprint in SavepointIterator by minimizing connection cache. [jone]
+- Reduce memory footprint in SavepointIterator by garbage-collecting connection cache. [jone]
 - Use a SavepointIterator in the WorkflowSecurityUpdater in order not to exceed
   memory. [mbaechtold]
 

--- a/ftw/upgrade/tests/test_savepoint_iterator.py
+++ b/ftw/upgrade/tests/test_savepoint_iterator.py
@@ -1,16 +1,16 @@
+from ftw.upgrade.testing import UPGRADE_FUNCTIONAL_TESTING
 from ftw.upgrade.utils import SavepointIterator
 from unittest2 import TestCase
 import transaction
 
 
 class TestSavepointIterator(TestCase):
+    layer = UPGRADE_FUNCTIONAL_TESTING
 
     def setUp(self):
+        super(TestSavepointIterator, self).setUp()
         self.iterable = [1, 2, 3, 4, 5]
         self.txn = transaction.get()
-
-    def tearDown(self):
-        self.txn.abort()
 
     def test_creates_savepoints(self):
         self.assertEquals(


### PR DESCRIPTION
Let the SavepointIterator ~minimize~ _garbage collect_ the connection cache in order to free up memory.
After a savepoint is used for moving the data from the memory to the disk we need to ~minimize~ _garbage collect_ the connection cache so that the amount of object is reduced to the allowed cache size.
This allows us to keep the memory footprint low.

Here is an example of the impact of this change in a test which uses the `WorkflowSecurityUpdater`, which updates the security of content objects and uses the `SavepointIterator`.

Before (without cache optimization):
<img width="1408" alt="bildschirmfoto 2017-11-28 um 20 32 25" src="https://user-images.githubusercontent.com/7469/33340065-512736e0-d47b-11e7-81af-76de3d26893a.png">

After (with cacheGC and zodb-cache-size reconfiguration; see below):
<img width="1408" alt="bildschirmfoto 2017-11-29 um 15 59 20" src="https://user-images.githubusercontent.com/7469/33381424-461e4ff6-d51e-11e7-971a-a7ae405c6b9a.png">
