### PR TITLE
Optimize memory footprint after every upgrade step.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2.8.2 (unreleased)
 ------------------
 
+- Optimize memory footprint after every upgrade step. [jone]
 - Reduce memory footprint in SavepointIterator by garbage-collecting connection cache. [jone]
 - Use a SavepointIterator in the WorkflowSecurityUpdater in order not to exceed
   memory. [mbaechtold]

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -9,6 +9,7 @@ from ftw.upgrade.resource_registries import recook_resources
 from ftw.upgrade.transactionnote import TransactionNote
 from ftw.upgrade.utils import format_duration
 from ftw.upgrade.utils import get_sorted_profile_ids
+from ftw.upgrade.utils import optimize_memory_usage
 from Products.CMFCore.utils import getToolByName
 from Products.GenericSetup.interfaces import ISetupTool
 from Products.GenericSetup.upgrade import _upgrade_registry
@@ -76,6 +77,7 @@ class Executioner(object):
             # the start.
             self.portal_setup.runAllImportStepsFromProfile(prefix + profile_id)
             logger.info('Done installing profile %s.', profile_id)
+            optimize_memory_usage()
         self._process_indexing_queue()
 
     security.declarePrivate('_register_after_commit_hook')


### PR DESCRIPTION
Call the memory optimization function after each executed upgrade step in order to prevent problems when executing multiple memory-intense upgrade steps in a row, where the upgrade step are not using the savepoint iterator.