### PR TITLE
Enable the savepoint iterator by default.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,6 +230,10 @@ The ``UpgradeStep`` class has various helper functions:
     If set to a non-zero value, the ``savepoints`` argument causes a transaction
     savepoint to be created every n items. This can be used to keep memory usage
     in check when creating large transactions.
+    The default value ``None`` indicates that we are not configuring this feature
+    and it should use the default configuration, which is usually ``1000``. See
+    the `Savepoints`_ section for more details.
+    In order to disable savepoints completely, you can use ``savepoints=False``.
 
     This method will remove matching brains from the catalog when they are broken
     because the object of the brain does no longer exist.
@@ -339,7 +343,7 @@ The ``UpgradeStep`` class has various helper functions:
     (``allowedRolesAndUsers``). This speeds up the update but should only be disabled
     when there are no changes for the ``View`` permission.
 
-``self.update_workflow_security(workflow_names, reindex_security=True, savepoints=1000)``
+``self.update_workflow_security(workflow_names, reindex_security=True, savepoints=None)``
     Update all objects which have one of a list of workflows.
     This is useful when updating a bunch of workflows and you want to make sure
     that the object security is updated properly.
@@ -1187,6 +1191,22 @@ Registration in ZCML:
             name="my.package:default" />
     </configure>
 
+
+Savepoints
+==========
+
+Certain iterators of ``ftw.upgrade`` are wrapped with a ``SavepointIterator``,
+creating savepoints after each batch of items.
+This allows us to keep the memory footprint low.
+
+The threshold for the savepoint iterator can be passed to certain methods, such as
+``self.objects`` in an upgrade, or it can be configured globally with an environment variable:
+
+.. code::
+
+  UPGRADE_SAVEPOINT_THRESHOLD = 1000
+
+The default savepoint threshold is 1000.
 
 Memory optimization while running upgrades
 ==========================================

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 
 - Optimize memory footprint after every upgrade step. [jone]
 - Reduce memory footprint in SavepointIterator by garbage-collecting connection cache. [jone]
+- Set the default savepoint threshold to 1000; make it configurable. [jone]
+- Enable savepoint iterator by default. Affects ``self.objects``. [jone]
 - Use a SavepointIterator in the WorkflowSecurityUpdater in order not to exceed
   memory. [mbaechtold]
 

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -87,7 +87,8 @@ class TestUpgradeStep(UpgradeTestCase):
             def __call__(self):
                 for obj in self.objects({'portal_type': 'Folder'},
                                         'Log message',
-                                        logger=testcase.logger):
+                                        logger=testcase.logger,
+                                        savepoints=False):
                     object_titles.append(obj.Title())
 
         Step(self.portal_setup)

--- a/ftw/upgrade/workflow.py
+++ b/ftw/upgrade/workflow.py
@@ -152,7 +152,7 @@ class WorkflowChainUpdater(object):
 
 class WorkflowSecurityUpdater(object):
 
-    def update(self, changed_workflows, reindex_security=True, savepoints=1000):
+    def update(self, changed_workflows, reindex_security=True, savepoints=None):
         types = self.get_suspected_types(changed_workflows)
         objects = SavepointIterator.build(self.lookup_objects(types), savepoints)
         for obj in objects:


### PR DESCRIPTION
- Enable the savepoint iterator by default. This affects primarely the `self.objects` method.
- Configure the default savepoint threshold to 1000.
- Make the default savepoint threshold configurable with the environment variable `UPGRADE_SAVEPOINT_THRESHOLD`, so that it can be fine tuned for each environment / host.

When passing a threshold to the iterator, use:
- `None` to use default threshold configured in the environment variable
- `False` to disable the iterator explicitly.