### PR TITLE
Support installing proposed upgrades of specific Generic Setup profiles

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 2.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Support installing proposed upgrades of specific Generic Setup profiles.
+  Use ``bin/upgrade install --proposed the.package:default``. [jone]
 
 2.9.0 (2017-12-14)
 ------------------

--- a/ftw/upgrade/command/install.py
+++ b/ftw/upgrade/command/install.py
@@ -73,12 +73,14 @@ def setup_argparser(commands):
     group = command.add_mutually_exclusive_group(required=True)
     group.add_argument('--upgrades', '-u', nargs='+',
                        help='One or many upgrade step API ids.',
-                       type=valid_upgrade_step_id)
+                       type=valid_upgrade_step_id,
+                       metavar='UPGRADE-STEP')
     group.add_argument('--proposed', '-p', action='store_true',
                        help='Installs all proposed upgrades.')
     group.add_argument('--profiles', nargs='+',
                        help='One or many profile ids.',
-                       type=valid_profile_id)
+                       type=valid_profile_id,
+                       metavar='PROFILE')
 
 
 @with_api_requestor

--- a/ftw/upgrade/command/install.py
+++ b/ftw/upgrade/command/install.py
@@ -17,6 +17,12 @@ DOCS = """
     When using the "--proposed" argument, all proposed upgrade steps are\
  installed, ordered by dependencies and versions.
 
+{t.bold}INSTALL PROPOSED UPGRADES OF SPECIFIC PROFILES:{t.normal}
+    The "--proposed" argument optionally accepts a list of profiles, \
+for which proposed upgrades are installed. \
+When no profile is specified, all proposed upgrades of all profiles \
+are installed.
+
 {t.bold}SET OF UPGRADES:{t.normal}
     By using the "--upgrades" argument, one or many upgrades can be \
 installed. \
@@ -35,6 +41,7 @@ Upgrades within each profile are ordered by the source / destination versions.
 [quote]
 $ bin/upgrade install --site Plone --proposed
 $ bin/upgrade install --site Plone --proposed --auth admin:admin
+$ bin/upgrade install --site Plone --proposed my.package:default other.package:default
 $ bin/upgrade install --site Plone --upgrades 3001@my.package:default \
 3002@my.package:default
 $ bin/upgrade install --site Plone --profiles Products.PloneFormGen:default \
@@ -75,8 +82,9 @@ def setup_argparser(commands):
                        help='One or many upgrade step API ids.',
                        type=valid_upgrade_step_id,
                        metavar='UPGRADE-STEP')
-    group.add_argument('--proposed', '-p', action='store_true',
-                       help='Installs all proposed upgrades.')
+    group.add_argument('--proposed', '-p', nargs='*',
+                       help='Installs all proposed upgrades of all or specific profiles.',
+                       metavar='PROFILE')
     group.add_argument('--profiles', nargs='+',
                        help='One or many profile ids.',
                        type=valid_profile_id,
@@ -90,9 +98,9 @@ def install_command(args, requestor):
         print >>sys.stderr, 'ERROR: --force can only be used with --profiles.'
         sys.exit(3)
 
-    if args.proposed:
+    if args.proposed is not None:
         action = 'execute_proposed_upgrades'
-        params = ()
+        params = [('profiles:list', name) for name in args.proposed]
     elif args.profiles:
         action = 'execute_profiles'
         params = [('profiles:list', name) for name in set(args.profiles)]


### PR DESCRIPTION
Solves #155

While `bin/install --proposed` still installs all upgrades for _all_ profiles, we now can also install the proposed upgrades of _specific_ profiles with `bin/install --proposed pkg.one:default pkg.two:default`.

I also changed the argument-metavars in the helptext of `bin/upgrade install` to be more precise:
```
usage: ./bin/upgrade install [-h] [--auth AUTH] [--verbose]
                             (--site SITE | --pick-site | --last-site | --all-sites)
                             [--force]
                             (--upgrades UPGRADE-STEP [UPGRADE-STEP ...] | --proposed [PROFILE [PROFILE ...]] | --profiles PROFILE [PROFILE ...])
``` 