### PR TITLE
Do not propose executed upgrades newer than current db version.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Provide upgrade step handler interfaces and handler class in wrapper. [jone]
+- Do not propose executed upgrades newer than current db version. [jone]
 
 2.10.0 (2018-01-08)
 -------------------


### PR DESCRIPTION
The goal of this change is that we do not want to propose upgrades which we already know were executed but the current profile id is too old.

With this change, upgrade steps are never proposed when the upgrade step recorder tells that the upgrade step was already executed. This is especially handy for customizations of the upgrade step recording behavior.

~~This has had the impact that upgrade steps between the current profile version and an upgrade step in the future which is already executed could not be detected as orphan because the the detection was based on the current profile version.  In order to do the orphan detection based on whether later upgrade steps are already installed, the upgrade step processing had to be reversed to be bottom-up.~~