### PR TITLE
Provide upgrade step handler interfaces and handler class in wrapper.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 2.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Provide upgrade step handler interfaces and handler class in wrapper. [jone]
 
 2.10.0 (2018-01-08)
 -------------------

--- a/ftw/upgrade/directory/wrapper.py
+++ b/ftw/upgrade/directory/wrapper.py
@@ -3,6 +3,7 @@ from ftw.upgrade.interfaces import IUpgradeStepRecorder
 from Products.CMFCore.utils import getToolByName
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
+from zope.interface import implementedBy
 
 
 def wrap_upgrade_step(handler, upgrade_profile, base_profile, target_version):
@@ -17,4 +18,6 @@ def wrap_upgrade_step(handler, upgrade_profile, base_profile, target_version):
         recorder.mark_as_installed(target_version)
         return result
     alsoProvides(upgrade_step_wrapper, IRecordableHandler)
+    alsoProvides(upgrade_step_wrapper, implementedBy(handler))
+    upgrade_step_wrapper.handler = handler
     return upgrade_step_wrapper


### PR DESCRIPTION
The interfaces implemented by the upgrade step class are now provided by the wrapper. This allows for classification and checks using interfaces.