### PR TITLE
Make sure remove_broken_browserlayer doesn't fail if browser layer doesn't exist

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.11.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make sure remove_broken_browserlayer() helper doesn't fail if the browser
+  layer registration to be removed doesn't exist (any more). [lgraf]
 
 
 2.11.0 (2018-01-31)

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -398,7 +398,7 @@ class UpgradeStep(object):
                                 if not layer.__name__ == iface_name])
         layer_subscribers[''] = remaining_layers
 
-        sm._utility_registrations.pop((ILocalBrowserLayerType, name))
+        sm._utility_registrations.pop((ILocalBrowserLayerType, name), None)
 
         sm.utilities._p_changed = True
 

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -755,6 +755,13 @@ class TestUpgradeStep(UpgradeTestCase):
         self.assertNotIn((ILocalBrowserLayerType, 'my.product'),
                          sm._utility_registrations)
 
+    def test_remove_broken_browserlayer_doesnt_fail_if_layer_missing(self):
+        class Step(UpgradeStep):
+            def __call__(self):
+                self.remove_broken_browserlayer('my.nonexistent.product',
+                                                'IMyNonexistentProductLayer')
+        Step(self.portal_setup)
+
     def test_remove_remove_broken_portlet_manager(self):
         from plone.portlets.interfaces import IPortletManager
         from plone.portlets.interfaces import IPortletManagerRenderer


### PR DESCRIPTION
Make sure the `remove_broken_browserlayer()` helper doesn't fail if the browser layer registration to be removed doesn't exist (any more).