### PR TITLE
Fix connection problem when zope.conf contains ip-address.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2.11.1 (unreleased)
 -------------------
 
+- Fix connection problem when zope.conf contains ip-address. [jone]
 - Make sure remove_broken_browserlayer() helper doesn't fail if the browser
   layer registration to be removed doesn't exist (any more). [lgraf]
 

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -216,7 +216,7 @@ def find_instance_zconfs(buildout_path):
 
 
 def get_instance_port(zconf):
-    match = re.search(r'address ([\d.]*:)?(\d+)', zconf.text())
+    match = re.search(r'\saddress ([\d.]*:)?(\d+)', zconf.text())
     if match:
         return int(match.group(2))
     return None


### PR DESCRIPTION
Fixes #163

The command line tool extracts the zope port from the zope.conf. The extraction was not robust enough and tripped when the optional zope.conf setting "ip-address" was used.

This change fixes the problem and adds tests for various zope.conf combinations.

The solution is to expect a whitespace before the address string, which can either be a newline (no indentation) or a space (with indentation).

/cc @mauritsvanrees 