### PR TITLE
Plone 4.3.7 tests: Pin previously unpinned p.a.contenttypes dependencies

### DIFF
--- a/test-plone-4.3.7.cfg
+++ b/test-plone-4.3.7.cfg
@@ -12,3 +12,9 @@ package-name = ftw.upgrade
 
 [versions]
 i18ndude = 4.3
+
+# p.a.contenttypes dependencies not pinned in 4.3.7 yet
+Products.DateRecurringIndex = 2.1
+collective.elephantvocabulary = 0.2.5
+plone.formwidget.querystring = 1.1.10
+plone.event = 1.3.3


### PR DESCRIPTION
Especially the pinning for Products.DateRecurringIndex to 2.1 is needed to get tests passing again for 4.3.7.

This is required because in versions newer than 2.1 `Products.DateRecurringIndex` now depends on the `ZODB` egg (instead of `ZODB3`) which results in a version conflict around the `transaction` module on Plone versions which don't use `ZODB` > 3.x yet.

This change was introduced in a [PEP8 commit](https://github.com/collective/Products.DateRecurringIndex/commit/e08fc4bec0281ed700f754087f3a286fc6d1891c) - don't know what to tell ya 😕  

Fixes [current test failures](https://ci.4teamwork.ch/builds/193283/tasks/316398).