### PR TITLE
Skip broken catalog brains in WorkflowSecurityUpdater.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 2.12.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Skip broken catalog brains in WorkflowSecurityUpdater. [phgross]
 
 2.12.0 (2018-07-26)
 -------------------

--- a/ftw/upgrade/tests/test_workflow.py
+++ b/ftw/upgrade/tests/test_workflow.py
@@ -1,3 +1,5 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.upgrade.placefulworkflow import PlacefulWorkflowPolicyActivator
@@ -259,3 +261,22 @@ class TestWorkflowSecurityUpdater(WorkflowTestCase):
         self.assert_permission_not_acquired(
             'View', document,
             'The document should have been updated but was not.')
+
+    def test_skip_broken_brains(self):
+        self.set_workflow_chain(for_type='Folder',
+                                to_workflow='folder_workflow')
+
+        folder1 = create(Builder('folder'))
+        folder2 = create(Builder('folder'))
+        folder3 = create(Builder('folder'))
+
+        # Delete folder and suppress events so that the catalog does not notice
+        # the object is gone, then try to get the object.
+        aq_parent(aq_inner(folder2))._delObject(folder2.getId(),
+                                                suppress_events=True)
+
+        updater = WorkflowSecurityUpdater()
+        generator = updater.lookup_objects('Folder')
+
+        self.assertEquals([folder1, folder3],
+                          [obj for obj in generator])

--- a/ftw/upgrade/workflow.py
+++ b/ftw/upgrade/workflow.py
@@ -166,8 +166,14 @@ class WorkflowSecurityUpdater(object):
         query = {'portal_type': types}
         brains = tuple(catalog.unrestrictedSearchResults(query))
 
-        lookup = lambda brain: portal.unrestrictedTraverse(brain.getPath())
-        generator = SizedGenerator((lookup(brain) for brain in brains),
+        def lookup(brain):
+            try:
+                return portal.unrestrictedTraverse(brain.getPath())
+            except KeyError:
+                return None
+
+        generator = (lookup(brain) for brain in brains)
+        generator = SizedGenerator((obj for obj in generator if obj),
                                    len(brains))
         return ProgressLogger('Update object security', generator)
 


### PR DESCRIPTION
Similar as it was done for self.objects (see #146), we now also skip broken brains when updating workflow_security via `update_workflow_security`. This should help to have workflow updates without difficulties.


