### PR TITLE
Hide upgrade step profiles from extensions panel.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.12.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Hide upgrade step profiles from extensions panel. [jone]
 
 
 2.12.0 (2018-07-26)

--- a/ftw/upgrade/directory/zcml.py
+++ b/ftw/upgrade/directory/zcml.py
@@ -3,7 +3,7 @@ from ftw.upgrade.directory.wrapper import wrap_upgrade_step
 from ftw.upgrade.exceptions import UpgradeStepConfigurationError
 from operator import attrgetter
 from Products.CMFPlone.interfaces import IMigratingPloneSiteRoot
-from Products.GenericSetup.interfaces import EXTENSION
+from Products.GenericSetup.interfaces import BASE
 from Products.GenericSetup.interfaces import IProfile
 from Products.GenericSetup.registry import _profile_registry
 from Products.GenericSetup.registry import GlobalRegistryStorage
@@ -98,7 +98,7 @@ def upgrade_step_directory_action(profile, dottedname, path,
             description='',
             path=upgrade_info['path'],
             product=dottedname,
-            profile_type=EXTENSION,
+            profile_type=BASE,
             for_=IMigratingPloneSiteRoot)
 
         last_version = upgrade_info['target-version']

--- a/ftw/upgrade/tests/test_directory_meta_directive.py
+++ b/ftw/upgrade/tests/test_directory_meta_directive.py
@@ -7,7 +7,7 @@ from ftw.upgrade.tests.base import UpgradeTestCase
 from ftw.upgrade.utils import get_sorted_profile_ids
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IMigratingPloneSiteRoot
-from Products.GenericSetup.interfaces import EXTENSION
+from Products.GenericSetup.interfaces import BASE
 from Products.GenericSetup.upgrade import listUpgradeSteps
 from zope.configuration.config import ConfigurationExecutionError
 from zope.interface import implementer
@@ -78,7 +78,7 @@ class TestDirectoryMetaDirective(UpgradeTestCase):
                  'description': '',
                  'path': upgrade_path,
                  'product': 'the.package.upgrades',
-                 'type': EXTENSION,
+                 'type': BASE,
                  'for': IMigratingPloneSiteRoot})
 
     def test_package_modules_is_not_corrupted(self):
@@ -97,7 +97,7 @@ class TestDirectoryMetaDirective(UpgradeTestCase):
                             name='default',
                             title='other.package:default',
                             directory='profiles/default',
-                            provides='Products.GenericSetup.interfaces.EXTENSION')
+                            provides='Products.GenericSetup.interfaces.BASE')
 
             .with_directory('upgrades')
             .with_file('upgrades/__init__.py', 'PACKAGE = "upgrades package"')
@@ -143,7 +143,7 @@ class TestDirectoryMetaDirective(UpgradeTestCase):
                  'path': profile_path,
                  'version': '20110202080000',
                  'product': 'the.package',
-                 'type': EXTENSION,
+                 'type': BASE,
                  'for': None})
 
     def test_profile_version_is_set_to_latest_old_school_profile_version(self):
@@ -175,7 +175,7 @@ class TestDirectoryMetaDirective(UpgradeTestCase):
                  'path': str(profile_path),
                  'version': '1001',
                  'product': 'the.package',
-                 'type': EXTENSION,
+                 'type': BASE,
                  'for': None})
 
     def test_version_set_to_default_when_no_upgrades_defined(self):
@@ -195,7 +195,7 @@ class TestDirectoryMetaDirective(UpgradeTestCase):
                  'path': profile_path,
                  'version': u'10000000000000',
                  'product': 'the.package',
-                 'type': EXTENSION,
+                 'type': BASE,
                  'for': None})
 
     def test_profile_must_not_have_a_metadata_version_defined(self):
@@ -251,7 +251,7 @@ class TestDirectoryMetaDirective(UpgradeTestCase):
                  'path': package.package_path.joinpath('profiles', 'foo'),
                  'version': u'20100101010100',
                  'product': 'the.package',
-                 'type': EXTENSION,
+                 'type': BASE,
                  'for': None})
 
             portal_setup = getToolByName(self.portal, 'portal_setup')

--- a/ftw/upgrade/zcml.py
+++ b/ftw/upgrade/zcml.py
@@ -1,6 +1,6 @@
 from ftw.upgrade import UpgradeStep
 from Products.CMFPlone.interfaces import IMigratingPloneSiteRoot
-from Products.GenericSetup.interfaces import EXTENSION
+from Products.GenericSetup.interfaces import BASE
 from Products.GenericSetup.zcml import registerProfile
 from Products.GenericSetup.zcml import upgradeStep
 from zope.configuration.fields import GlobalObject
@@ -53,7 +53,7 @@ def importProfileUpgradeStep(_context, title, profile, source, destination,
     profile_id = "upgrade_to_%s" % destination
     registerProfile(_context, name=profile_id, title=title,
                     description=description, directory=directory,
-                    provides=EXTENSION, for_=IMigratingPloneSiteRoot)
+                    provides=BASE, for_=IMigratingPloneSiteRoot)
 
     if handler is None:
         handler = DefaultUpgradeStep


### PR DESCRIPTION
Upgrade step Generic Setup profiles are now registered as BASE profile rather than as EXTENSION. This removes the profiles from the extensions control panel in Plone 5.