### PR TITLE
Disable Diazo on upgrades-plain for Plone 5.1.5 support.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.12.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Disable Diazo on upgrades-plain for Plone 5.1.5 support. [jone]
 
 
 2.12.0 (2018-07-26)

--- a/ftw/upgrade/browser/manage.py
+++ b/ftw/upgrade/browser/manage.py
@@ -178,3 +178,7 @@ class ManageUpgradesPlain(ManageUpgrades):
 
     def __getitem__(self, key):
         return self.index.macros[key]
+
+    def __call__(self):
+        self.request.response.setHeader('X-Theme-Disabled', 'true')
+        return super(ManageUpgradesPlain, self).__call__()


### PR DESCRIPTION
In order to avoid an encoding in Plone >= 5.1.5 problem when not using the main template, Diazo should be disabled for non-main-template views.