### PR TITLE
Tests: Choose actual port used by ZServer layer to run CommandAndInstance tests against

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2.12.1 (unreleased)
 -------------------
 
+- Choose actual port used by ZServer layer to run CommandAndInstance tests against. [lgraf]
 - Disable Diazo on upgrades-plain for Plone 5.1.5 support. [jone]
 
 

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -346,5 +346,6 @@ class CommandAndInstanceTestCase(JsonApiTestCase, CommandTestCase):
         return etc1.dirname()
 
     def write_zconf_with_test_instance(self):
-        test_instance_port = os.environ.get('ZSERVER_PORT', 55001)
+        # Determine the port the ZServer layer has picked
+        test_instance_port = self.layer['port']
         self.write_zconf('instance', test_instance_port)

--- a/ftw/upgrade/tests/test_command_jsonapi.py
+++ b/ftw/upgrade/tests/test_command_jsonapi.py
@@ -77,7 +77,7 @@ class TestJsonAPIUtils(CommandAndInstanceTestCase):
 
     def test_get_api_url(self):
         self.write_zconf_with_test_instance()
-        test_instance_port = os.environ.get('ZSERVER_PORT', 55001)
+        test_instance_port = self.layer['port']
 
         self.assertEqual(
             'http://localhost:{0}/upgrades-api/foo'.format(test_instance_port),
@@ -93,7 +93,7 @@ class TestJsonAPIUtils(CommandAndInstanceTestCase):
 
     def test_get_api_url_with_public_url(self):
         self.write_zconf_with_test_instance()
-        test_instance_port = os.environ.get('ZSERVER_PORT', 55001)
+        test_instance_port = self.layer['port']
 
         os.environ['UPGRADE_PUBLIC_URL'] = 'http://domain.com'
         self.assertEqual(
@@ -128,7 +128,7 @@ class TestJsonAPIUtils(CommandAndInstanceTestCase):
             get_zope_url()
 
     def test_find_first_running_instance_info(self):
-        test_instance_port = int(os.environ.get('ZSERVER_PORT', 55001))
+        test_instance_port = self.layer['port']
         self.write_zconf('instance1', '1000')
         part2 = self.write_zconf('instance2', test_instance_port)
         self.assertEqual(
@@ -137,7 +137,7 @@ class TestJsonAPIUtils(CommandAndInstanceTestCase):
             get_running_instance(self.layer['root_path']))
 
     def test_find_first_running_instance_info_with_network_interface(self):
-        test_instance_port = int(os.environ.get('ZSERVER_PORT', 55001))
+        test_instance_port = self.layer['port']
         self.write_zconf('instance1', '1000')
         part2 = self.write_zconf('instance2',
                                  '0.0.0.0:{0}'.format(test_instance_port))
@@ -147,7 +147,7 @@ class TestJsonAPIUtils(CommandAndInstanceTestCase):
             get_running_instance(self.layer['root_path']))
 
     def test_find_first_running_instance_info_named_zeoclient(self):
-        test_zeoclient_port = int(os.environ.get('ZSERVER_PORT', 55001))
+        test_zeoclient_port = self.layer['port']
         self.write_zconf('zeoclient1', '1000')
         part2 = self.write_zconf('zeoclient2', test_zeoclient_port)
         self.assertEqual(


### PR DESCRIPTION
Currently `CommandAndInstance` tests on Plone 5 are failing **when run locally** with

```
AssertionError: Expected exit code 0, got 1 for "/private/var/folders/..._/sample-buildout/bin/upgrade sites --json".
Output:
ERROR: No running Plone instance detected.
```

The reason for these failures is, that when run locally, with Plone 5, the ZServer won't be running on 55001 any more (which our code expects), but on a **dynamic port randomly assigned by the OS**.

The `CommandAndInstance` tests write a pseudo-zconf with the HTTP port where they should expect a running Plone instance (as set up by the `plone.testing.z2.ZServer` layer).

In more recent versions, if `ZSERVER_PORT` is not set, the ZServer layer lets the OS pick a dynamic port for the ZServer it boots, instead of defaulting to port `55001` (which it did in earlier versions).

Compare
- [`plone.testing:4.1.2`](https://github.com/plone/plone.testing/blob/4.1.2/src/plone/testing/z2.py#L973) vs
- [`plone.testing:4.3.2`](https://github.com/plone/plone.testing/blob/4.3.2/src/plone/testing/z2.py#L972)


This meant that Plone 5 tests were failing locally, because we always defaulted to `55001` if `ZSERVER_PORT` wasn't set (which it usually isn't when running tests locally).

Therefore we instead just read out the actual port that the ZServer picked, and write that to the pseudo-zconf.