### PR TITLE
Make sure to always use a portal_migration tool wrapped in a RequestContainer

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.12.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make sure to always use a portal_migration tool wrapped in a RequestContainer.
+  (Fixes "AttributeError: REQUEST" on a Plone 5.1.x upgrade) [lgraf]
 
 
 2.12.1 (2019-06-18)

--- a/ftw/upgrade/browser/manage.py
+++ b/ftw/upgrade/browser/manage.py
@@ -1,9 +1,10 @@
 from AccessControl.SecurityInfo import ClassSecurityInformation
-from Products.CMFCore.utils import getToolByName
 from ftw.upgrade.exceptions import CyclicDependencies
 from ftw.upgrade.interfaces import IExecutioner
 from ftw.upgrade.interfaces import IUpgradeInformationGatherer
 from ftw.upgrade.utils import format_duration
+from ftw.upgrade.utils import get_portal_migration
+from Products.CMFCore.utils import getToolByName
 from zope.component import getAdapter
 from zope.publisher.browser import BrowserView
 import logging
@@ -136,7 +137,7 @@ class ManageUpgrades(BrowserView):
 
     security.declarePrivate('plone_needs_upgrading')
     def plone_needs_upgrading(self):
-        portal_migration = getToolByName(self.context, 'portal_migration')
+        portal_migration = get_portal_migration(self.context)
         return portal_migration.needUpgrading()
 
     security.declarePrivate('_get_upgrades_to_install')

--- a/ftw/upgrade/jsonapi/plonesite.py
+++ b/ftw/upgrade/jsonapi/plonesite.py
@@ -10,6 +10,7 @@ from ftw.upgrade.jsonapi.utils import action
 from ftw.upgrade.jsonapi.utils import jsonify
 from ftw.upgrade.jsonapi.utils import parse_bool
 from ftw.upgrade.resource_registries import recook_resources
+from ftw.upgrade.utils import get_portal_migration
 from operator import itemgetter
 from Products.CMFCore.utils import getToolByName
 
@@ -101,7 +102,7 @@ class PloneSiteAPI(APIView):
 
         This is what you would manually do in the @@plone-upgrade view.
         """
-        portal_migration = getToolByName(self.context, 'portal_migration')
+        portal_migration = get_portal_migration(self.context)
         if not portal_migration.needUpgrading():
             return 'Plone Site was already up to date.'
         portal_migration.upgrade(swallow_errors=False)
@@ -112,7 +113,7 @@ class PloneSiteAPI(APIView):
     def plone_upgrade_needed(self):
         """Returns "true" when Plone needs to be upgraded.
         """
-        portal_migration = getToolByName(self.context, 'portal_migration')
+        portal_migration = get_portal_migration(self.context)
         return bool(portal_migration.needUpgrading())
 
     def _refine_profile_info(self, profile):
@@ -183,6 +184,6 @@ class PloneSiteAPI(APIView):
             raise AbortTransactionWithStreamedResponse(exc)
 
     def _require_up_to_date_plone_site(self):
-        portal_migration = getToolByName(self.context, 'portal_migration')
+        portal_migration = get_portal_migration(self.context)
         if portal_migration.needUpgrading():
             raise PloneSiteOutdated()

--- a/ftw/upgrade/tests/test_command_plone_upgrade.py
+++ b/ftw/upgrade/tests/test_command_plone_upgrade.py
@@ -1,7 +1,11 @@
+from Acquisition import aq_chain
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
+from ftw.upgrade.utils import get_portal_migration
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import getFSVersionTuple
 from unittest2 import skipIf
+from ZPublisher.BaseRequest import RequestContainer
+from ZPublisher.HTTPRequest import HTTPRequest
 import transaction
 
 
@@ -33,3 +37,10 @@ class TestPloneUpgradeCommand(CommandAndInstanceTestCase):
         self.assertEquals(0, exitcode)
         transaction.begin()  # sync transaction
         self.assertIn(u'Plone Site has been updated.', output)
+
+    def test_portal_migration_tool_is_wrapped_in_request_container(self):
+        portal = self.layer['portal']
+        portal_migration = get_portal_migration(portal)
+
+        self.assertIsInstance(portal_migration.REQUEST, HTTPRequest)
+        self.assertIsInstance(aq_chain(portal_migration)[-1], RequestContainer)

--- a/ftw/upgrade/tests/test_jsonapi_plonesite.py
+++ b/ftw/upgrade/tests/test_jsonapi_plonesite.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from ftw.builder import Builder
 from ftw.testbrowser import browsing
 from ftw.upgrade.tests.base import JsonApiTestCase
-from Products.CMFCore.utils import getToolByName
+from ftw.upgrade.utils import get_portal_migration
 from Products.CMFPlone.factory import _DEFAULT_PROFILE
 import re
 import transaction
@@ -366,7 +366,7 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
 
     @browsing
     def test_execute_upgrades_not_allowed_when_plone_outdated(self, browser):
-        portal_migration = getToolByName(self.layer['portal'], 'portal_migration')
+        portal_migration = get_portal_migration(self.layer['portal'])
         portal_migration.setInstanceVersion('1.0.0')
         transaction.commit()
 

--- a/ftw/upgrade/utils.py
+++ b/ftw/upgrade/utils.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from ftw.upgrade.exceptions import CyclicDependencies
 from path import Path
+from Products.CMFCore.utils import getToolByName
 from zope.component.hooks import getSite
 import logging
 import math
@@ -321,3 +322,10 @@ def log_silencer(logger_name, criteria):
         yield
     finally:
         log.removeFilter(filt)
+
+
+def get_portal_migration(context):
+    """Make sure we always acquire the portal_migration tool the same way.
+    """
+    portal_migration = getToolByName(context, 'portal_migration')
+    return portal_migration


### PR DESCRIPTION
The `portal_migration` tool is registered as a tool utility by Plone. This implies that it can work when fetched "out of thin air" as a utility.

However, this is not strictly the case: Some Plone upgrades make use of `self.REQUEST` (directly or indirectly), which only works if the `portal_migration` tool is wrapped in a `RequestContainer`.

If `portal_migration` is fetched via `getToolByName`, it *won't* be wrapped in a `RequestContainer`, because [`getToolByName` first looks for a utility](https://github.com/zopefoundation/Products.CMFCore/blob/2.3.0/Products/CMFCore/utils.py#L89), and if it finds one, happily returns that.

Instead, the `portal_migration` tool needs to be looked up via acquisition (using `getattr`). This is what Plone itself [does in its `@@plone-upgrade` view](https://github.com/plone/Products.CMFPlone/blob/d43517ed9ca0593cf74c0d013fe7a933c912fe5e/Products/CMFPlone/browser/admin.py#L284), and it will lead to the `portal_migration` tool having a `RequestContainer` in its AQ chain.

Please see #170 for a more in depth explanation.

Fixes #170.