### PR TITLE
Update section "compatibility" in the readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ additional buildout part:
 Compatibility
 -------------
 
-Compatible with Plone 4.3.x.
+Compatible with Plone 4.3.x and 5.1.x.
 
 
 Manage upgrades


### PR DESCRIPTION
Support for Plone 5.1.x has been added in 2.5.0:

https://github.com/4teamwork/ftw.upgrade/blob/466e7930ba67e639af6362218ea0dfb8ca7b049a/docs/HISTORY.txt#L108-L111

Closes https://github.com/4teamwork/ftw.upgrade/issues/176