### PR TITLE
Added combine_bundles command for Plone 5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -695,7 +695,7 @@ Creating an upgrade step
 
 Upgrade steps can be generated with ``ftw.upgrade``'s ``bin/upgrade`` console script.
 The idea is to install this script with buildout using
-`zc.recipe.egg <https://pypi.python.org/pypi/zc.recipe.egg>`_.
+`zc.recipe.egg <https://pypi.org/project/zc.recipe.egg/>`_.
 
 Once installed, upgrade steps can simply be scaffolded with the script:
 
@@ -1274,7 +1274,7 @@ Links
 
 - Github: https://github.com/4teamwork/ftw.upgrade
 - Issues: https://github.com/4teamwork/ftw.upgrade/issues
-- Pypi: http://pypi.python.org/pypi/ftw.upgrade
+- Pypi: https://pypi.org/project/ftw.upgrade/
 - Continuous integration: https://jenkins.4teamwork.ch/search?q=ftw.upgrade
 
 

--- a/README.rst
+++ b/README.rst
@@ -1145,6 +1145,20 @@ CSS and JavaScript resource bundles can be recooked:
     "OK"
 
 
+Combine bundles
+---------------
+
+CSS and JavaScript bundles can be combined:
+
+.. code:: sh
+
+    $ curl -uadmin:admin -X POST http://localhost:8080/Plone/upgrades-api/combine_bundles
+    "OK"
+
+This is for Plone 5 or higher.
+This runs the same code that runs when you import a profile that makes changes in the resource registries.
+
+
 Import-Profile Upgrade Steps
 ============================
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.12.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Added combine_bundles command for Plone 5.
+  This combines JS/CSS bundles together.  [maurits]
 
 
 2.12.2 (2019-06-19)

--- a/ftw/upgrade/command/__init__.py
+++ b/ftw/upgrade/command/__init__.py
@@ -1,3 +1,4 @@
+from ftw.upgrade.command import combine_bundles
 from ftw.upgrade.command import create
 from ftw.upgrade.command import help
 from ftw.upgrade.command import install
@@ -129,6 +130,7 @@ class UpgradeCommand(object):
         argcomplete.autocomplete(self.parser)
 
         commands = self.parser.add_subparsers(help='Command')
+        combine_bundles.setup_argparser(commands)
         create.setup_argparser(commands)
         install.setup_argparser(commands)
         list_cmd.setup_argparser(commands)

--- a/ftw/upgrade/command/combine_bundles.py
+++ b/ftw/upgrade/command/combine_bundles.py
@@ -1,0 +1,31 @@
+from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
+from ftw.upgrade.command.jsonapi import add_site_path_argument
+from ftw.upgrade.command.jsonapi import error_handling
+from ftw.upgrade.command.jsonapi import with_api_requestor
+from ftw.upgrade.command.terminal import TERMINAL
+
+
+DOCS = """
+{t.bold}DESCRIPTION:{t.normal}
+    Combine JS/CSS bundles together (Plone 5).
+[quote]
+    $ ./bin/upgrade combine_bundles --site Plone
+[/quote]
+""".format(
+    t=TERMINAL
+).strip()
+
+
+def setup_argparser(commands):
+    command = commands.add_parser(
+        'combine_bundles', help='Combine JS/CSS bundles together (Plone 5).', description=DOCS
+    )
+    command.set_defaults(func=combine_bundles)
+    add_requestor_authentication_argument(command)
+    add_site_path_argument(command)
+
+
+@with_api_requestor
+@error_handling
+def combine_bundles(args, requestor):
+    print(requestor.POST('combine_bundles').json())

--- a/ftw/upgrade/jsonapi/configure.zcml
+++ b/ftw/upgrade/jsonapi/configure.zcml
@@ -16,6 +16,7 @@
                             execute_proposed_upgrades
                             plone_upgrade
                             plone_upgrade_needed
+                            combine_bundles
                             recook_resources"
         />
 

--- a/ftw/upgrade/jsonapi/plonesite.py
+++ b/ftw/upgrade/jsonapi/plonesite.py
@@ -97,6 +97,19 @@ class PloneSiteAPI(APIView):
 
     @jsonify
     @action('POST')
+    def combine_bundles(self):
+        """Combine JS/CSS bundles together.
+
+        Since this is only for Plone 5 or higher, we do the import inline.
+        The imported function was introduced in Plone 5.0.3.
+        """
+        from Products.CMFPlone.resources.browser.combine import combine_bundles
+
+        combine_bundles(self.context)
+        return 'OK'
+
+    @jsonify
+    @action('POST')
     def plone_upgrade(self):
         """Upgrade the Plone Site.
 

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browser
@@ -126,6 +127,21 @@ class UpgradeTestCase(TestCase):
         yield
         self.assertNotEqual(resources, get_resources(),
                             'Resurces are not recooked.')
+
+    @contextmanager
+    def assert_bundles_combined(self):
+        # Note: this is for Plone 5.
+
+        def get_timestamp():
+            timestamp_file = self.portal.portal_resources.resource_overrides.production['timestamp.txt']
+            # The data contains text, which should be a DateTime.
+            # Convert it to an actual DateTime object so we can be sure when comparing it.
+            return DateTime(timestamp_file.data)
+
+        timestamp = get_timestamp()
+        yield
+        self.assertLess(timestamp, get_timestamp(),
+                        'Timestamp has not been updated.')
 
     def setup_logging(self):
         self.log = StringIO()

--- a/ftw/upgrade/tests/test_command_combine_bundles.py
+++ b/ftw/upgrade/tests/test_command_combine_bundles.py
@@ -1,0 +1,20 @@
+from ftw.upgrade.tests.base import CommandAndInstanceTestCase
+from Products.CMFPlone.utils import getFSVersionTuple
+from unittest2 import skipIf
+import transaction
+
+
+class TestCombineBundlesCommand(CommandAndInstanceTestCase):
+    def setUp(self):
+        super(TestCombineBundlesCommand, self).setUp()
+        self.write_zconf_with_test_instance()
+
+    def test_help(self):
+        self.upgrade_script('combine_bundles --help')
+
+    @skipIf(getFSVersionTuple() < (5,), 'The test only works on Plone 5+.')
+    def test_combine_bundles(self):
+        with self.assert_bundles_combined():
+            exitcode, output = self.upgrade_script('combine_bundles -s plone')
+            self.assertEqual('OK\n', output)
+            transaction.begin()


### PR DESCRIPTION
This combines JS/CSS bundles together.

Thanks to @lukasgraf for the hints on how to create a new command (via @fredvd).

Strictly speaking, it would be better to not show this command in the help when the site is Plone 4, but I am not sure if that is easily possible. An extra command here should not be a big deal though.