### PR TITLE
Fix tests

### DIFF
--- a/ftw/upgrade/tests/test_jsonapi_plonesite.py
+++ b/ftw/upgrade/tests/test_jsonapi_plonesite.py
@@ -17,7 +17,13 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
         self.assert_json_equal(
             {'api_version': 'v1',
              'actions':
-                 [{'description': ('Executes a list of profiles, each '
+                 [{'description': 'Combine JS/CSS bundles together. Since this '
+                   'is only for Plone 5 or higher, we do the import inline. The '
+                   'imported function was introduced in Plone 5.0.3.',
+                   'name': 'combine_bundles',
+                   'request_method': 'POST',
+                   'required_params': []},
+                  {'description': ('Executes a list of profiles, each '
                                    'identified by their ID.'),
                    'name': 'execute_profiles',
                    'request_method': 'POST',


### PR DESCRIPTION
Because PR #178 came from an external fork, our CI didn't run tests :-(

We therefore missed a test that asserted on available commands that needed to be extended with the newly added command.