### PR TITLE
Fix tests after Plone 4.3.19 release.

### DIFF
--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -150,9 +150,11 @@ class TestUpgradeStep(UpgradeTestCase):
         class Step(UpgradeStep):
             def __call__(self):
                 ctool = self.getToolByName('portal_catalog')
-                name = 'rights'
+                name = 'modified'
+                testcase.assertEqual(1, ctool._catalog.getIndex(name).indexSize())
+                self.catalog_remove_index(name)
 
-                self.catalog_add_index(name, 'FieldIndex')
+                self.catalog_add_index(name, 'DateIndex')
                 testcase.assertEqual(0, ctool._catalog.getIndex(name).indexSize())
                 self.catalog_rebuild_index(name)
                 testcase.assertEqual(1, ctool._catalog.getIndex(name).indexSize())
@@ -169,9 +171,11 @@ class TestUpgradeStep(UpgradeTestCase):
         class Step(UpgradeStep):
             def __call__(self):
                 ctool = self.getToolByName('portal_catalog')
-                name = 'rights'
+                name = 'modified'
+                testcase.assertEqual(1, ctool._catalog.getIndex(name).indexSize())
+                self.catalog_remove_index(name)
 
-                self.catalog_add_index(name, 'FieldIndex')
+                self.catalog_add_index(name, 'DateIndex')
                 testcase.assertEqual(0, ctool._catalog.getIndex(name).indexSize())
 
                 self.catalog_reindex_objects({'portal_type': 'Folder'})


### PR DESCRIPTION
The tests were relying on a value in the attribute "rights", which was not actually on the folder object but seems to have been inherited through acquisition. The Plone 4.3.19 release does no longer index parent attributes through acquisition, thus the test was failing.
We have now a more relyable approach by removing an existing index and re-adding it.


