### PR TITLE
Added --allow-outdated option to install command.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 2.13.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Added ``--allow-outdated`` option to ``install`` command.
+  This allows installing upgrades or profiles on a not up-to-date site.
+  Fixes `issue 182 <https://github.com/4teamwork/ftw.upgrade/issues/182>`.
 
 
 2.13.0 (2019-08-22)

--- a/ftw/upgrade/command/install.py
+++ b/ftw/upgrade/command/install.py
@@ -98,6 +98,15 @@ def setup_argparser(commands):
                          dest='skip_deferrable',
                          action='store_true')
 
+    command.add_argument('--allow-outdated',
+                         help='Allow installing on outdated Plone site. '
+                              'By default we do not allow this, '
+                              'because it is better to first run the '
+                              'plone_upgrade command.',
+                         default=False,
+                         dest='allow_outdated',
+                         action='store_true')
+
 
 @with_api_requestor
 @error_handling
@@ -119,6 +128,8 @@ def install_command(args, requestor):
     else:
         action = 'execute_upgrades'
         params = [('upgrades:list', name) for name in set(args.upgrades)]
+    if args.allow_outdated:
+        params.append(('allow_outdated', True))
 
     with closing(requestor.POST(action, params=params,
                                 stream=True)) as response:

--- a/ftw/upgrade/jsonapi/plonesite.py
+++ b/ftw/upgrade/jsonapi/plonesite.py
@@ -56,19 +56,22 @@ class PloneSiteAPI(APIView):
             self._get_proposed_upgrades(propose_deferrable=propose_deferrable))
 
     @action('POST', rename_params={'upgrades': 'upgrades:list'})
-    def execute_upgrades(self, upgrades):
+    def execute_upgrades(self, upgrades, allow_outdated=False):
         """Executes a list of upgrades, each identified by the upgrade ID
         in the form "[dest-version]@[profile ID]".
         """
-        self._require_up_to_date_plone_site()
+        if not allow_outdated:
+            self._require_up_to_date_plone_site()
         self._validate_upgrade_ids(*upgrades)
         return self._install_upgrades(*upgrades)
 
     @action('POST', rename_params={'profiles': 'profiles:list'})
-    def execute_proposed_upgrades(self, profiles=None, propose_deferrable=True):
+    def execute_proposed_upgrades(self, profiles=None, propose_deferrable=True,
+            allow_outdated=False):
         """Executes all proposed upgrades.
         """
-        self._require_up_to_date_plone_site()
+        if not allow_outdated:
+            self._require_up_to_date_plone_site()
         if profiles:
             self._validate_profile_ids(*profiles)
         propose_deferrable = parse_bool(propose_deferrable)
@@ -79,10 +82,12 @@ class PloneSiteAPI(APIView):
             *api_ids, propose_deferrable=propose_deferrable)
 
     @action('POST', rename_params={'profiles': 'profiles:list'})
-    def execute_profiles(self, profiles, force_reinstall=False):
+    def execute_profiles(self, profiles, force_reinstall=False,
+            allow_outdated=False):
         """Executes a list of profiles, each identified by their ID.
         """
-        self._require_up_to_date_plone_site()
+        if not allow_outdated:
+            self._require_up_to_date_plone_site()
         self._validate_profile_ids(*profiles)
         return self._install_profiles(*profiles,
                                       force_reinstall=force_reinstall)


### PR DESCRIPTION
This allows installing upgrades or profiles on a not up-to-date site.
Fixes issue #182.

I updated the `test_execute_upgrades_not_allowed_when_plone_outdated` method.
It was trying a command that failed with a 400 error because the Plone Site was outdated.
But when the Plone Site was *not* outdated, it would have failed with a different 400 error, because the wanted upgrade step did not exist.
Updated it to use an existing upgrade step.
Duplicated the test to check that it works when adding our new `--allow-outdated` option.
I could also combine it into one test if wanted, but technically it is more correct to have two tests.
