### PR TITLE
Inplace migrator: correct migration of empty RichTextFields

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.14.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Inplace migrator: do not create empty RichTextValue objects, use None istead. [djowett-ftw]
 
 
 2.14.0 (2019-10-31)

--- a/ftw/upgrade/migration.py
+++ b/ftw/upgrade/migration.py
@@ -436,7 +436,10 @@ class InplaceMigrator(object):
 
         if IRichText.providedBy(field) \
            and not IRichTextValue.providedBy(value):
-            return recurse(field.fromUnicode(value))
+            if not value:
+                return None
+            else:
+                return recurse(field.fromUnicode(value))
 
         if INamedField.providedBy(field) and value is not None \
            and not isinstance(value, field._type):


### PR DESCRIPTION
When nothing is entered into a rich text field in Plone, `None` is stored.
The inplace migrator used to create an empty `RichTextValue`, which was causing trouble later.
The correct behavior is that `None` is created on falsy values.


(Cherry-Picked from @djowett-ftw, added changelog entry)