### PR TITLE
Migrate creators even when dublin core behaviors are not enabled.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.14.1 (unreleased)
 -------------------
 
+- Migrate creators even when dublin core behaviors are not enabled. [jone]
+
 - Migrate empty values in RichTextFields correctly.
   Fixes `https://github.com/4teamwork/izug.refegovservice/issues/2`. [djowett-ftw]
 

--- a/ftw/upgrade/migration.py
+++ b/ftw/upgrade/migration.py
@@ -193,6 +193,7 @@ class InplaceMigrator(object):
             self.add_relations_to_relation_catalog,
             self.migrate_properties,
             self.migrate_constrain_types_configuration,
+            self.update_creators,
         )
         self.additional_steps = additional_steps
         self.final_steps = (
@@ -555,6 +556,13 @@ class InplaceMigrator(object):
             filter(isallowed, old_ct.getLocallyAllowedTypes()))
         new_ct.setImmediatelyAddableTypes(
             filter(isallowed, old_ct.getImmediatelyAddableTypes()))
+
+    def update_creators(self, old_object, new_object):
+        """When the dublin core behavior is active, the creators are migrated already.
+        But when the dublin core behavior is missing, we need to fix the creators list here.
+        """
+        if old_object.listCreators() != new_object.listCreators():
+            new_object.setCreators(old_object.listCreators())
 
     def update_creation_date(self, old_object, new_object):
         new_object.creation_date = (


### PR DESCRIPTION
The Dexterity base class has support for creators (it implements listCreators() and other methods. The dublin core behavior makes it possible to edit the creators.

The migration did work when the dublin core behavior was enabled. But when it was not enabled, the creators was overwritten by the user executing the migration. This change updates the creators.