### PR TITLE
Allow disabling marking upgrade steps as installed on profile import.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1283,6 +1283,35 @@ In order for this to work properly you should configure your ZODB cache sizes co
 (`zodb-cache-size-bytes` or `zodb-cache-size`).
 
 
+Prevent ftw.upgrade from marking upgrades as installed
+======================================================
+
+``ftw.upgrade`` automatically marks all upgrade steps of a profile as installed when
+the full profile is imported. This is important for the initial installation.
+
+In certain situations you may want to import the profile but not mark the upgrade steps
+as installed. For example this could be done in a big migration project where the default
+migration path cannot be followed.
+
+You can do that like this for all generic setup profiles:
+
+.. code:: python
+
+    from ftw.upgrade.directory.subscribers import no_upgrade_step_marking
+
+    with no_upgrade_step_marking():
+        # install profile with portal_setup
+
+or for certain generic setup profiles:
+
+.. code:: python
+
+    from ftw.upgrade.directory.subscribers import no_upgrade_step_marking
+
+    with no_upgrade_step_marking('my.package:default'):
+        # install profile with portal_setup
+
+
 
 Links
 =====

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.14.2 (unreleased)
 -------------------
 
+- Add context manager for disabling upgrade step marking. [jone]
+
 - Do not mark upgrade steps as installed when not doing a full import. [jone]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.14.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Do not mark upgrade steps as installed when not doing a full import. [jone]
 
 
 2.14.1 (2019-11-08)

--- a/ftw/upgrade/directory/subscribers.py
+++ b/ftw/upgrade/directory/subscribers.py
@@ -10,6 +10,9 @@ def profile_installed(event):
     if not event.profile_id:
         return
 
+    if not event.full_import:
+        return
+
     profile = re.sub('^profile-', '', event.profile_id)
     portal = getToolByName(event.tool, 'portal_url').getPortalObject()
     recorder = getMultiAdapter((portal, profile), IUpgradeStepRecorder)

--- a/ftw/upgrade/directory/subscribers.py
+++ b/ftw/upgrade/directory/subscribers.py
@@ -1,9 +1,35 @@
+from contextlib import contextmanager
 from ftw.upgrade.gatherer import flatten_upgrades
 from ftw.upgrade.interfaces import IUpgradeStepRecorder
+from functools import partial
 from operator import itemgetter
 from Products.CMFCore.utils import getToolByName
 from zope.component import getMultiAdapter
+import os
 import re
+
+
+DISABLE_UPGRADE_STEP_MARKING_KEY = 'ftw_upgrade_disable_upgrade_step_marking'
+ALL_FLAG = 'all'
+
+
+@contextmanager
+def no_upgrade_step_marking(*only_profiles):
+    if only_profiles:
+        value = ','.join(map(partial(re.sub, '^profile-', ''), only_profiles))
+    else:
+        value = ALL_FLAG
+
+    previous_value = os.environ.get(DISABLE_UPGRADE_STEP_MARKING_KEY, None)
+    os.environ[DISABLE_UPGRADE_STEP_MARKING_KEY] = value
+
+    try:
+        yield
+    finally:
+        if previous_value:
+            os.environ[DISABLE_UPGRADE_STEP_MARKING_KEY] = previous_value
+        else:
+            os.environ.pop(DISABLE_UPGRADE_STEP_MARKING_KEY, None)
 
 
 def profile_installed(event):
@@ -13,7 +39,11 @@ def profile_installed(event):
     if not event.full_import:
         return
 
+    disabled_for_profiles = os.environ.get(DISABLE_UPGRADE_STEP_MARKING_KEY, '').split(',')
     profile = re.sub('^profile-', '', event.profile_id)
+    if profile in disabled_for_profiles or ALL_FLAG in disabled_for_profiles:
+        return
+
     portal = getToolByName(event.tool, 'portal_url').getPortalObject()
     recorder = getMultiAdapter((portal, profile), IUpgradeStepRecorder)
 

--- a/ftw/upgrade/tests/test_directory_upgrade_steps.py
+++ b/ftw/upgrade/tests/test_directory_upgrade_steps.py
@@ -44,6 +44,26 @@ class TestDirectoryUpgradeSteps(UpgradeTestCase):
                 'Expected upgrade steps to be marked as installed'
                 ' after importing profile.')
 
+    def test_installing_profile_does_not_mark_upgrade_step_as_installed_on_partial_import(self):
+        self.package.with_profile(Builder('genericsetup profile')
+                                  .with_upgrade(Builder('ftw upgrade step')
+                                                .to(datetime(2011, 1, 1))))
+
+        with self.package_created():
+            recorder = getMultiAdapter((self.portal, 'the.package:default'),
+                                       IUpgradeStepRecorder)
+            self.assertFalse(
+                recorder.is_installed('20110101000000'),
+                'Expected upgrade steps to not be marked as installed'
+                ' before importing profile.')
+
+            self.portal_setup.runImportStepFromProfile('profile-the.package:default', 'typeinfo')
+
+            self.assertFalse(
+                recorder.is_installed('20110101000000'),
+                'Expected upgrade steps to not be marked as installed'
+                ' because of a partial import.')
+
     def test_associated_upgrade_step_profile_is_imported(self):
         class AddTestAction(UpgradeStep):
             def __call__(self):

--- a/ftw/upgrade/tests/test_directory_upgrade_steps.py
+++ b/ftw/upgrade/tests/test_directory_upgrade_steps.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.upgrade import UpgradeStep
+from ftw.upgrade.directory.subscribers import no_upgrade_step_marking
 from ftw.upgrade.interfaces import IExecutioner
 from ftw.upgrade.interfaces import IUpgradeStepRecorder
 from ftw.upgrade.tests.base import UpgradeTestCase
@@ -63,6 +64,43 @@ class TestDirectoryUpgradeSteps(UpgradeTestCase):
                 recorder.is_installed('20110101000000'),
                 'Expected upgrade steps to not be marked as installed'
                 ' because of a partial import.')
+
+    def test_context_manager_for_disabling_upgrade_step_marking(self):
+        self.package.with_profile(Builder('genericsetup profile')
+                                  .with_upgrade(Builder('ftw upgrade step')
+                                                .to(datetime(2011, 1, 1))))
+
+        with self.package_created():
+            recorder = getMultiAdapter((self.portal, 'the.package:default'),
+                                       IUpgradeStepRecorder)
+            self.assertFalse(
+                recorder.is_installed('20110101000000'),
+                'Expected upgrade steps to not be marked as installed'
+                ' before importing profile.')
+
+            with no_upgrade_step_marking():
+                self.install_profile('the.package:default')
+
+            self.assertFalse(
+                recorder.is_installed('20110101000000'),
+                'Expected upgrade steps to not be marked as installed'
+                ' because marking is prevented for all profiles.')
+
+            with no_upgrade_step_marking('the.package:default'):
+                self.install_profile('the.package:default')
+
+            self.assertFalse(
+                recorder.is_installed('20110101000000'),
+                'Expected upgrade steps to not be marked as installed'
+                ' because marking is prevented for this profile.')
+
+            with no_upgrade_step_marking('OTHER.package:default'):
+                self.install_profile('the.package:default')
+
+            self.assertTrue(
+                recorder.is_installed('20110101000000'),
+                'Expected upgrade steps to be marked as installed'
+                ' because it is only prevented for other profiles.')
 
     def test_associated_upgrade_step_profile_is_imported(self):
         class AddTestAction(UpgradeStep):


### PR DESCRIPTION
For a migration project we need to be able to import the generic setup profile (in an upgrade step) without marking all other upgrade steps as installed.

In order to do that, two changes are made in this PR:

- Upgrade steps are no longer marked as installed when only importing a partial GS profile.
- There is a context manager for temporary disabling the marking of upgrade steps.

See the readme for usage instructions.