### PR TITLE
Migration: reindex reverse relations in zc.catalog.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.15.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Migration: reindex reverse relations in zc.catalog. [jone]
 
 
 2.15.0 (2019-12-12)


### PR DESCRIPTION
After migrating from AT to DX, the relations in the zc.catalog need to be reindex in order to have the correct interfaces.

Not doing that can result in broken persistent interfaces when the interface definition is removed from the code.