### PR TITLE
Cleanup broken catalog brains on NotFound.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,7 +237,7 @@ The ``UpgradeStep`` class has various helper functions:
     In order to disable savepoints completely, you can use ``savepoints=False``.
 
     This method will remove matching brains from the catalog when they are broken
-    because the object of the brain does no longer exist.
+    because the object of the brain no longer exists.
     The progress logger will not compensate for the skipped objects and terminate
     before reaching 100%.
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.15.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Cleanup broken catalog brains on `NotFound`. [jone]
 
 
 2.15.0 (2019-12-12)

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -15,6 +15,7 @@ from Products.BTreeFolder2.BTreeFolder2 import BTreeFolder2Base
 from Products.CMFCore.ActionInformation import ActionInformation
 from Products.CMFCore.utils import getToolByName
 from Products.ZCatalog.ProgressHandler import ZLogHandler
+from zExceptions import NotFound
 from zope.browser.interfaces import IBrowserView
 from zope.event import notify
 from zope.interface import directlyProvidedBy
@@ -154,7 +155,7 @@ class UpgradeStep(object):
         """
         try:
             return self.portal.unrestrictedTraverse(brain.getPath())
-        except (AttributeError, KeyError):
+        except (AttributeError, KeyError, NotFound):
             LOG.warning('The object of the brain with rid {!r} does no longer'
                         ' exist at the path {!r}; removing the brain.'.format(
                             brain.getRID(), brain.getPath()))

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -156,8 +156,8 @@ class UpgradeStep(object):
         try:
             return self.portal.unrestrictedTraverse(brain.getPath())
         except (AttributeError, KeyError, NotFound):
-            LOG.warning('The object of the brain with rid {!r} does no longer'
-                        ' exist at the path {!r}; removing the brain.'.format(
+            LOG.warning('The object of the brain with rid {!r} no longer'
+                        ' exists at the path {!r}; removing the brain.'.format(
                             brain.getRID(), brain.getPath()))
             catalog = self.getToolByName('portal_catalog')
             catalog.uncatalog_object(brain.getPath())

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -258,7 +258,7 @@ class TestUpgradeStep(UpgradeTestCase):
 
     def test_catalog_unrestricted_get_object_removes_dead_brains(self):
         """From time to time there are brains in the catalog for which the
-        object does no longer exist.
+        object no longer exists.
         This can happen because of bugs such as when a "deleted"-event-subscriber
         indexes the object.
 
@@ -285,7 +285,7 @@ class TestUpgradeStep(UpgradeTestCase):
                     'Should return None in order to work well with .objects()')
 
                 testcase.assertIn(
-                    "The object of the brain with rid {!r} does no longer exist"
+                    "The object of the brain with rid {!r} no longer exists"
                     " at the path '/plone/folder'; removing the brain.".format(
                         brain.getRID()),
                     testcase.get_log())
@@ -333,7 +333,7 @@ class TestUpgradeStep(UpgradeTestCase):
 
     def test_catalog_unrestricted_search_filters_nonexisting_objects(self):
         """From time to time there are brains in the catalog for which the
-        object does no longer exist.
+        object no longer exists.
         This can happen because of bugs such as when a "deleted"-event-subscriber
         indexes the object.
 


### PR DESCRIPTION
`unrestrictedTraverse` may also raise a `NotFound` exception. In this case we want to clean up by removing the brain.