### PR TITLE
Fix tests for python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,16 @@ import os
 
 version = '2.15.2.dev0'
 
+if sys.version_info[0] == 2:
+    pyversion_requires = [
+        'setuptools < 45',
+        'more-itertools < 6.0'
+    ]
+else:
+    pyversion_requires = [
+        'setuptools'
+    ]
+
 tests_require = [
     'ftw.testing >= 1.8.1',
     'ftw.testbrowser',
@@ -58,7 +68,6 @@ setup(name='ftw.upgrade',
         'inflection',
         'path.py >= 6.2',
         'requests',
-        'setuptools',
         'tarjan',
 
         # Zope
@@ -78,7 +87,7 @@ setup(name='ftw.upgrade',
         'plone.browserlayer',
         'Products.CMFCore',
         'Products.CMFPlone',
-        ],
+        ] + pyversion_requires,
 
       tests_require=tests_require,
       extras_require=extras_require,

--- a/test-plone-4.3.7.cfg
+++ b/test-plone-4.3.7.cfg
@@ -18,3 +18,5 @@ Products.DateRecurringIndex = 2.1
 collective.elephantvocabulary = 0.2.5
 plone.formwidget.querystring = 1.1.10
 plone.event = 1.3.3
+# python2 versions
+more-itertools = < 6.0.0

--- a/test-plone-4.3.7.cfg
+++ b/test-plone-4.3.7.cfg
@@ -19,4 +19,5 @@ collective.elephantvocabulary = 0.2.5
 plone.formwidget.querystring = 1.1.10
 plone.event = 1.3.3
 # python2 versions
+setuptools = < 45.0
 more-itertools = < 6.0.0

--- a/test-plone-4.3.x-with-blessed.cfg
+++ b/test-plone-4.3.x-with-blessed.cfg
@@ -7,4 +7,5 @@ test-egg = ${buildout:package-name} [tests, colors]
 
 [versions]
 # python2 versions
+setuptools = < 45.0
 more-itertools = < 6.0.0

--- a/test-plone-4.3.x-with-blessed.cfg
+++ b/test-plone-4.3.x-with-blessed.cfg
@@ -4,3 +4,7 @@ extends =
 
 package-name = ftw.upgrade
 test-egg = ${buildout:package-name} [tests, colors]
+
+[versions]
+# python2 versions
+more-itertools = < 6.0.0

--- a/test-plone-4.3.x-with-collective.indexing.cfg
+++ b/test-plone-4.3.x-with-collective.indexing.cfg
@@ -4,3 +4,7 @@ extends =
 
 [test]
 eggs += collective.indexing
+
+[versions]
+# python2 versions
+more-itertools = < 6.0.0

--- a/test-plone-4.3.x-with-collective.indexing.cfg
+++ b/test-plone-4.3.x-with-collective.indexing.cfg
@@ -7,4 +7,5 @@ eggs += collective.indexing
 
 [versions]
 # python2 versions
+setuptools = < 45.0
 more-itertools = < 6.0.0

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -11,3 +11,5 @@ eggs += plone4.csrffixes
 
 [versions]
 plone.protect = 3.0.19
+# python2 versions
+more-itertools = < 6.0.0

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -11,5 +11,7 @@ eggs += plone4.csrffixes
 
 [versions]
 plone.protect = 3.0.19
+
 # python2 versions
+setuptools = < 45.0
 more-itertools = < 6.0.0

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -5,4 +5,5 @@ package-name = ftw.upgrade
 
 [versions]
 # python2 versions
+setuptools = < 45.0
 more-itertools = < 6.0.0

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -2,3 +2,7 @@
 extends = https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
 
 package-name = ftw.upgrade
+
+[versions]
+# python2 versions
+more-itertools = < 6.0.0


### PR DESCRIPTION
This fixes the nightly tests for ftw.upgrade where `more-itertools` was unpinned, and setuptools was kicking out a python2 warning.  Is the work in `setup.py` a bit too much though?