### PR TITLE
Fix missing values in IntIds catalog as we go in migrate_intid()

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.15.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix missing values in IntIds catalog as we go within migrate_intid(). [djowett-ftw]
 
 
 2.15.1 (2019-12-16)


### PR DESCRIPTION
This was necessary in bl.web AT -> DX migration for 'ftw.file.File's where many Files were found to not be in the IntIds catalog.

An alternative might be to call `plone.app.intid.setuphandlers.register_all_content_for_intids` at the start of that upgrade step

related to https://github.com/4teamwork/bl.web/issues/584