### PR TITLE
Support Plone 5.2

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.16.1 (unreleased)
 -------------------
 
+- Do not cook resources in ``portal_css`` and ``portal_javascripts`` when these tools do not exist.
+  This is needed for Plone 5.2.  [maurits]
+
 - Start on Plone 5.2 support by also looking for the instance port number in ``wsgi.ini``.  [maurits]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.16.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Start on Plone 5.2 support by also looking for the instance port number in ``wsgi.ini``.  [maurits]
 
 
 2.16.0 (2020-02-14)

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -212,11 +212,19 @@ def get_running_instance(buildout_path):
 
 
 def find_instance_zconfs(buildout_path):
-    return sorted(buildout_path.glob('parts/*/etc/zope.conf'))
+    return sorted(
+        buildout_path.glob('parts/*/etc/zope.conf')
+        + buildout_path.glob('parts/*/etc/wsgi.ini')
+    )
 
 
 def get_instance_port(zconf):
+    # zope.conf
     match = re.search(r'\saddress ([\d.]*:)?(\d+)', zconf.text())
+    if match:
+        return int(match.group(2))
+    # wsgi.ini
+    match = re.search(r'\slisten = ([\d.]*:)?(\d+)', zconf.text())
     if match:
         return int(match.group(2))
     return None

--- a/ftw/upgrade/resource_registries.py
+++ b/ftw/upgrade/resource_registries.py
@@ -5,8 +5,13 @@ from zope.component.hooks import getSite
 
 
 def recook_resources():
+    site = getSite()
     for name in ('portal_css', 'portal_javascripts'):
-        registry = getToolByName(getSite(), name)
+        try:
+            registry = getToolByName(site, name)
+        except AttributeError:
+            # Plone 5.2+ without the old-style resource registries
+            continue
         registry.cookResources()
 
     # Plone 5: clear all bundles


### PR DESCRIPTION
This fixes the problems described in issue #195, except for Python 3.

- Fix getting the zope port, because we need to check `wsgi.ini` now. After this, several commands work again, including the `sites` and `plone_upgrade` commands.
- Do not fail for cooking resources when `portal_css` and `portal_javascripts` are not there. Now the `install --proposed` command works again.

I briefly tried adding a `test-plone-5.2.x.cfg`, but got into setuptools version conflicts when running buildout. I did not try to solve that.
