### PR TITLE
Plone 5.2 and Python 3 support

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Add support for Plone 5.2 and Python 3. [buchi]
+- Also look for the instance port number in ``wsgi.ini``.  [maurits]
 
 
 2.16.0 (2020-02-14)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-2.16.1 (unreleased)
--------------------
+3.0.0 (unreleased)
+------------------
 
-- Nothing changed yet.
+- Add support for Plone 5.2 and Python 3. [buchi]
 
 
 2.16.0 (2020-02-14)

--- a/ftw/upgrade/__init__.py
+++ b/ftw/upgrade/__init__.py
@@ -2,8 +2,10 @@
 # W0104: Statement seems to have no effect
 
 
+from ftw.upgrade.progresslogger import ProgressLogger
 from ftw.upgrade.step import UpgradeStep
+
+
 UpgradeStep
 
-from ftw.upgrade.progresslogger import ProgressLogger
 ProgressLogger

--- a/ftw/upgrade/browser/manage.py
+++ b/ftw/upgrade/browser/manage.py
@@ -115,17 +115,17 @@ class ManageUpgrades(BrowserView):
         response = self.request.RESPONSE
         response.setHeader('Content-Type', 'text/html')
         response.setHeader('Transfer-Encoding', 'chunked')
-        response.write('<html>')
-        response.write('<body>')
-        response.write('  ' * getattr(response, 'http_chunk_size', 100))
-        response.write('<pre>')
+        response.write(b'<html>')
+        response.write(b'<body>')
+        response.write(b'  ' * getattr(response, 'http_chunk_size', 100))
+        response.write(b'<pre>')
 
         with ResponseLogger(self.request.RESPONSE):
             self.install()
 
-        response.write('</pre>')
-        response.write('</body>')
-        response.write('</html>')
+        response.write(b'</pre>')
+        response.write(b'</body>')
+        response.write(b'</html>')
 
     security.declarePrivate('get_data')
     def get_data(self):

--- a/ftw/upgrade/browser/manage.py
+++ b/ftw/upgrade/browser/manage.py
@@ -58,7 +58,7 @@ class ResponseLogger(object):
         if isinstance(line, six.text_type):
             line = line.encode('utf8')
 
-        line = line.replace('<', '&lt;').replace('>', '&gt;')
+        line = line.replace(b'<', b'&lt;').replace(b'>', b'&gt;')
 
         self.response.write(line)
         self.response.flush()

--- a/ftw/upgrade/browser/manage.py
+++ b/ftw/upgrade/browser/manage.py
@@ -7,7 +7,9 @@ from ftw.upgrade.utils import get_portal_migration
 from Products.CMFCore.utils import getToolByName
 from zope.component import getAdapter
 from zope.publisher.browser import BrowserView
+
 import logging
+import six
 import time
 import traceback
 
@@ -53,7 +55,7 @@ class ResponseLogger(object):
 
     security.declarePrivate('write')
     def write(self, line):
-        if isinstance(line, unicode):
+        if isinstance(line, six.text_type):
             line = line.encode('utf8')
 
         line = line.replace('<', '&lt;').replace('>', '&gt;')
@@ -131,7 +133,7 @@ class ManageUpgrades(BrowserView):
         gatherer = getAdapter(gstool, IUpgradeInformationGatherer)
         try:
             return gatherer.get_profiles()
-        except CyclicDependencies, exc:
+        except CyclicDependencies as exc:
             self.cyclic_dependencies = exc.cyclic_dependencies
             return []
 

--- a/ftw/upgrade/command/__init__.py
+++ b/ftw/upgrade/command/__init__.py
@@ -168,7 +168,7 @@ class UpgradeCommand(object):
                     break
             if getattr(args, 'json', False):
                 # Pretty print the output of all sites.
-                print((json.dumps(info, indent=4, encoding='utf-8')))
+                print((json.dumps(info, indent=4)))
         else:
             args.func(args)
 

--- a/ftw/upgrade/command/__init__.py
+++ b/ftw/upgrade/command/__init__.py
@@ -13,6 +13,7 @@ from ftw.upgrade.command.formatter import FlexiFormatter
 from ftw.upgrade.command.terminal import TERMINAL
 from ftw.upgrade.command.utils import capture
 from pkg_resources import get_distribution
+
 import argcomplete
 import argparse
 import json
@@ -167,7 +168,7 @@ class UpgradeCommand(object):
                     break
             if getattr(args, 'json', False):
                 # Pretty print the output of all sites.
-                print(json.dumps(info, indent=4, encoding='utf-8'))
+                print((json.dumps(info, indent=4, encoding='utf-8')))
         else:
             args.func(args)
 

--- a/ftw/upgrade/command/combine_bundles.py
+++ b/ftw/upgrade/command/combine_bundles.py
@@ -28,4 +28,4 @@ def setup_argparser(commands):
 @with_api_requestor
 @error_handling
 def combine_bundles(args, requestor):
-    print(requestor.POST('combine_bundles').json())
+    print((requestor.POST('combine_bundles').json()))

--- a/ftw/upgrade/command/create.py
+++ b/ftw/upgrade/command/create.py
@@ -1,8 +1,10 @@
+from __future__ import print_function
 from ftw.upgrade.command.terminal import TERMINAL
 from ftw.upgrade.command.utils import find_egginfo
 from ftw.upgrade.command.utils import find_package_namespace_path
 from ftw.upgrade.directory.scaffold import UpgradeStepCreator
 from path import Path
+
 import argparse
 import sys
 
@@ -59,13 +61,13 @@ def create_command(args):
         upgrades_directory = default_upgrades_directory()
 
     if upgrades_directory is None:
-        print >>sys.stderr, 'ERROR: Please provide the path to ' + \
-            'the upgrades directory with --path.'
+        print('ERROR: Please provide the path to '
+              'the upgrades directory with --path.', file=sys.stderr)
         sys.exit(1)
 
     creator = UpgradeStepCreator(upgrades_directory)
     upgrade_step_directory = creator.create(args.title)
-    print 'Created upgrade step at:', upgrade_step_directory
+    print('Created upgrade step at:', upgrade_step_directory)
 
 
 def upgrades_path(path):
@@ -86,12 +88,11 @@ def default_upgrades_directory():
     package_namespace_path = find_package_namespace_path(egginfo)
     upgrades_dirs = tuple(package_namespace_path.walkdirs('upgrades'))
     if len(upgrades_dirs) == 0:
-        print >>sys.stderr, 'WARNING: no "upgrades" directory could be found.'
+        print('WARNING: no "upgrades" directory could be found.', file=sys.stderr)
         return None
 
     if len(upgrades_dirs) > 1:
-        print >>sys.stderr, 'WARNING: more than one "upgrades"' + \
-            ' directory found.'
+        print('WARNING: more than one "upgrades" directory found.', file=sys.stderr)
         return None
 
     return upgrades_dirs[0]

--- a/ftw/upgrade/command/formatter.py
+++ b/ftw/upgrade/command/formatter.py
@@ -1,6 +1,7 @@
 # Source: http://bugs.python.org/issue12806
 
 from ftw.upgrade.command.terminal import TERMINAL
+
 import argparse
 import re
 import textwrap

--- a/ftw/upgrade/command/help.py
+++ b/ftw/upgrade/command/help.py
@@ -1,4 +1,5 @@
 from ftw.upgrade.command.terminal import TERMINAL
+
 import argparse
 import os
 import pydoc
@@ -24,7 +25,7 @@ def setup_argparser(commands):
     command.set_defaults(func=help_command)
 
     command.add_argument('command', nargs='?',
-                         choices=get_commands(commands.container).keys(),
+                         choices=list(get_commands(commands.container).keys()),
                          help='Command to describe.')
 
 
@@ -35,7 +36,7 @@ def help_command(args):
         if os.system('(less -R) 2>/dev/null') == 0:
             return pydoc.pipepager(parser.format_help(), cmd='less -R')
     else:
-        print parser.format_help()
+        print(parser.format_help())
 
 
 def get_commands(parser):

--- a/ftw/upgrade/command/install.py
+++ b/ftw/upgrade/command/install.py
@@ -137,8 +137,7 @@ def install_command(args, requestor):
     with closing(requestor.POST(action, params=params,
                                 stream=True)) as response:
         for line in response.iter_lines(chunk_size=30):
-            if isinstance(line, six.text_type):
-                line = line.encode('utf-8')
+            line = six.ensure_str(line)
 
             print(line)
 

--- a/ftw/upgrade/command/install.py
+++ b/ftw/upgrade/command/install.py
@@ -1,10 +1,13 @@
+from __future__ import print_function
 from contextlib import closing
 from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
 from ftw.upgrade.command.jsonapi import add_site_path_argument
 from ftw.upgrade.command.jsonapi import error_handling
 from ftw.upgrade.command.jsonapi import with_api_requestor
 from ftw.upgrade.command.terminal import TERMINAL
+
 import re
+import six
 import sys
 
 
@@ -112,7 +115,7 @@ def setup_argparser(commands):
 @error_handling
 def install_command(args, requestor):
     if args.force_reinstall and not args.profiles:
-        print >>sys.stderr, 'ERROR: --force can only be used with --profiles.'
+        print('ERROR: --force can only be used with --profiles.', file=sys.stderr)
         sys.exit(3)
 
     if args.proposed is not None:
@@ -134,10 +137,10 @@ def install_command(args, requestor):
     with closing(requestor.POST(action, params=params,
                                 stream=True)) as response:
         for line in response.iter_lines(chunk_size=30):
-            if isinstance(line, unicode):
+            if isinstance(line, six.text_type):
                 line = line.encode('utf-8')
 
-            print line
+            print(line)
 
     if line.strip() != 'Result: SUCCESS':
         sys.exit(3)

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -217,11 +217,19 @@ def get_running_instance(buildout_path):
 
 
 def find_instance_zconfs(buildout_path):
-    return sorted(buildout_path.glob('parts/*/etc/zope.conf'))
+    return sorted(
+        buildout_path.glob('parts/*/etc/zope.conf')
+        + buildout_path.glob('parts/*/etc/wsgi.ini')
+    )
 
 
 def get_instance_port(zconf):
+    # zope.conf
     match = re.search(r'\saddress ([\d.]*:)?(\d+)', zconf.text())
+    if match:
+        return int(match.group(2))
+    # wsgi.ini
+    match = re.search(r'\slisten = ([\d.]*:)?(\d+)', zconf.text())
     if match:
         return int(match.group(2))
     return None

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import requests
+import six
 import socket
 import sys
 import tempfile
@@ -68,7 +69,7 @@ class TempfileAuth(AuthBase):
                                  hashlib.sha256).hexdigest()
         self.authfile = tempfile.NamedTemporaryFile(
             dir=directory)
-        self.authfile.write(self.authhash)
+        self.authfile.write(six.ensure_binary(self.authhash))
         self.authfile.flush()
         # Make sure the file is readable by the group, so that the service
         # user running Zope can read it even when it is not the creator.

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from binascii import hexlify
 from ftw.upgrade.utils import get_tempfile_authentication_directory
 from path import Path
 from requests.auth import AuthBase
@@ -62,8 +63,8 @@ class TempfileAuth(AuthBase):
 
     def _generate_tempfile(self):
         directory = self._get_temp_directory()
-        self.authhash = hmac.new(os.urandom(32).encode('hex'),
-                                 os.urandom(32).encode('hex'),
+        self.authhash = hmac.new(hexlify(os.urandom(32)),
+                                 hexlify(os.urandom(32)),
                                  hashlib.sha256).hexdigest()
         self.authfile = tempfile.NamedTemporaryFile(
             dir=directory)

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -238,6 +238,7 @@ def get_instance_port(zconf):
 def is_port_open(port):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     result = sock.connect_ex(('127.0.0.1', port))
+    sock.close()
     return result == 0
 
 

--- a/ftw/upgrade/command/list_cmd.py
+++ b/ftw/upgrade/command/list_cmd.py
@@ -68,7 +68,7 @@ def setup_argparser(commands):
 def list_command(args, requestor):
     response = requestor.GET(args.action)
     if args.json:
-        print response.text
+        print(response.text)
         return
 
     if args.action == 'list_proposed_upgrades':
@@ -89,7 +89,7 @@ def format_proposed_upgrades(response):
                      ]
         proposed.append(table_row)
 
-    print TERMINAL.bold('Proposed upgrades:')
+    print(TERMINAL.bold('Proposed upgrades:'))
     print_table(proposed, ['ID:', 'Title:'])
 
 
@@ -102,5 +102,5 @@ def format_profiles(response):
              TERMINAL.bold(profile['title']),
              colorized_profile_versions(profile)])
 
-    print TERMINAL.bold('Installed profiles:')
+    print(TERMINAL.bold('Installed profiles:'))
     print_table(tabledata, ['ID:', '', 'Title:', 'Versions (DB/FS):'])

--- a/ftw/upgrade/command/plone_upgrade.py
+++ b/ftw/upgrade/command/plone_upgrade.py
@@ -4,6 +4,8 @@ from ftw.upgrade.command.jsonapi import add_site_path_argument
 from ftw.upgrade.command.jsonapi import error_handling
 from ftw.upgrade.command.jsonapi import with_api_requestor
 from ftw.upgrade.command.terminal import TERMINAL
+
+import six
 import sys
 
 
@@ -45,10 +47,10 @@ def plone_upgrade_command(args, requestor):
     with closing(requestor.POST(action, params=params,
                                 stream=True)) as response:
         for line in response.iter_lines(chunk_size=30):
-            if isinstance(line, unicode):
+            if isinstance(line, six.text_type):
                 line = line.encode('utf-8')
 
-            print line
+            print(line)
 
     line = line.strip()
     if not any([x in line for x in expected]):

--- a/ftw/upgrade/command/plone_upgrade.py
+++ b/ftw/upgrade/command/plone_upgrade.py
@@ -34,8 +34,8 @@ def setup_argparser(commands):
 
 # expected output
 expected = (
-    u'Plone Site was already up to date.',
-    u'Plone Site has been updated.')
+    b'Plone Site was already up to date.',
+    b'Plone Site has been updated.')
 
 
 @with_api_requestor

--- a/ftw/upgrade/command/plone_upgrade_needed.py
+++ b/ftw/upgrade/command/plone_upgrade_needed.py
@@ -3,6 +3,7 @@ from ftw.upgrade.command.jsonapi import add_site_path_argument
 from ftw.upgrade.command.jsonapi import error_handling
 from ftw.upgrade.command.jsonapi import with_api_requestor
 from ftw.upgrade.command.terminal import TERMINAL
+
 import sys
 
 
@@ -32,6 +33,6 @@ def setup_argparser(commands):
 @error_handling
 def plone_upgrade_command(args, requestor):
     response = requestor.GET('plone_upgrade_needed')
-    print response.text
+    print(response.text)
     if response.text.strip() not in ('true', 'false'):
         sys.exit(3)

--- a/ftw/upgrade/command/recook.py
+++ b/ftw/upgrade/command/recook.py
@@ -27,4 +27,4 @@ def setup_argparser(commands):
 @with_api_requestor
 @error_handling
 def recook_command(args, requestor):
-    print requestor.POST('recook_resources').json()
+    print(requestor.POST('recook_resources').json())

--- a/ftw/upgrade/command/sites.py
+++ b/ftw/upgrade/command/sites.py
@@ -5,6 +5,8 @@ from ftw.upgrade.command.jsonapi import error_handling
 from ftw.upgrade.command.jsonapi import with_api_requestor
 from ftw.upgrade.command.terminal import TERMINAL
 
+import six
+
 
 DOCS = """
 {t.bold}DESCRIPTION:{t.normal}
@@ -38,4 +40,4 @@ def sites_command(args, requestor):
         print(response.text)
     else:
         for site in response.json():
-            print(site['path'].ljust(20), site['title'].encode('utf-8'))
+            print(site['path'].ljust(20), six.ensure_str(site['title']))

--- a/ftw/upgrade/command/sites.py
+++ b/ftw/upgrade/command/sites.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from ftw.upgrade.command.jsonapi import add_json_argument
 from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
 from ftw.upgrade.command.jsonapi import error_handling
@@ -34,7 +35,7 @@ def sites_command(args, requestor):
     response = requestor.GET('list_plone_sites')
 
     if args.json:
-        print response.text
+        print(response.text)
     else:
         for site in response.json():
-            print site['path'].ljust(20), site['title'].encode('utf-8')
+            print(site['path'].ljust(20), site['title'].encode('utf-8'))

--- a/ftw/upgrade/command/terminal.py
+++ b/ftw/upgrade/command/terminal.py
@@ -1,4 +1,8 @@
+from __future__ import print_function
 from operator import itemgetter
+from six.moves import filter
+from six.moves import map
+from six.moves import zip
 
 
 class FakeTerminal(str):
@@ -19,7 +23,7 @@ class FakeTerminal(str):
 
 try:
     from blessed import Terminal
-except ImportError, exc:
+except ImportError:
     Terminal = FakeTerminal
 
 
@@ -35,14 +39,14 @@ FLAGS = {
 
 def print_table(data, titles=None, colspace=1):
     if titles:
-        data.insert(0, map(TERMINAL.bright_black, titles))
+        data.insert(0, list(map(TERMINAL.bright_black, titles)))
 
-    column_lengths = map(max, zip(*map(
-                lambda row: map(TERMINAL.length, row), data)))
+    column_lengths = list(map(max, zip(
+        *[list(map(TERMINAL.length, row)) for row in data])))
     for row in data:
         for col_num, cell in enumerate(row):
-            print TERMINAL.ljust(cell, column_lengths[col_num] + colspace),
-        print ''
+            print(TERMINAL.ljust(cell, column_lengths[col_num] + colspace), end=' ')
+        print('')
 
 
 def upgrade_id_with_flags(upgrade, omit_flags=()):
@@ -74,11 +78,11 @@ def colorized_profile_flags(profile):
     if profile['outdated_fs_version']:
         flags.append(FLAGS['outdated_fs_version'])
 
-    proposed = len(filter(itemgetter('proposed'), profile['upgrades']))
+    proposed = len(list(filter(itemgetter('proposed'), profile['upgrades'])))
     if proposed:
         flags.append(TERMINAL.blue('{0} proposed'.format(proposed)))
 
-    orphans = len(filter(itemgetter('orphan'), profile['upgrades']))
+    orphans = len(list(filter(itemgetter('orphan'), profile['upgrades'])))
     if orphans:
         flags.append(TERMINAL.standout_red('{0} orphan'.format(orphans)))
 

--- a/ftw/upgrade/command/touch.py
+++ b/ftw/upgrade/command/touch.py
@@ -1,9 +1,13 @@
+from __future__ import print_function
 from datetime import datetime
 from datetime import timedelta
 from ftw.upgrade.command.terminal import TERMINAL
 from ftw.upgrade.directory.scaffold import DATETIME_FORMAT
 from ftw.upgrade.directory.scanner import UPGRADESTEP_DATETIME_REGEX
 from path import Path
+from six.moves import filter
+from six.moves import map
+
 import argparse
 import re
 import sys
@@ -74,10 +78,10 @@ def touch_command(args):
                                     args.after_path,
                                     args.before_path))))
     if len(parents) > 1:
-        print >>sys.stderr, 'ERORR: All paths must be in the same directory,', \
-            'got:'
+        print('ERROR: All paths must be in the same directory, got:',
+              file=sys.stderr)
         for parent in parents:
-            print '-', parent
+            print('-', parent)
         sys.exit(1)
 
     new_date = find_new_date(args)
@@ -86,7 +90,7 @@ def touch_command(args):
         args.path.name)
     new_path = args.path.dirname().joinpath(new_name)
     args.path.rename(new_path)
-    print 'New path:', new_path
+    print('New path:', new_path)
 
 
 def upgrade_step_path(path):
@@ -111,9 +115,9 @@ def find_new_date(args):
         return datetime.now()
 
     upgrades = sorted(
-        filter(None,
-               map(path_to_datetime,
-                   Path(args.path.dirname()).glob('*/upgrade.py'))))
+        [_f for _f in map(path_to_datetime,
+                          Path(args.path.dirname()).glob('*/upgrade.py'))
+         if _f])
     upgrades.remove(path_to_datetime(args.path))
 
     if after and upgrades[-1] == after:

--- a/ftw/upgrade/command/user.py
+++ b/ftw/upgrade/command/user.py
@@ -29,4 +29,4 @@ def setup_argparser(commands):
 @error_handling
 def sites_command(args, requestor):
     response = requestor.GET('current_user')
-    print 'Authenticated as "{0}".'.format(response.json())
+    print('Authenticated as "{0}".'.format(response.json()))

--- a/ftw/upgrade/command/utils.py
+++ b/ftw/upgrade/command/utils.py
@@ -1,5 +1,7 @@
-from StringIO import StringIO
+from __future__ import print_function
 from path import Path
+from StringIO import StringIO
+
 import contextlib
 import os
 import sys
@@ -8,7 +10,8 @@ import sys
 def find_egginfo(path=None):
     path = path or Path(os.getcwd())
     if not path or path == '/':
-        print >>sys.stderr, 'WARNING: no *.egg-info directory could be found.'
+        print('WARNING: no *.egg-info directory could be found.',
+              file=sys.stderr)
         return None
 
     egginfos = path.dirs('*.egg-info')
@@ -16,8 +19,8 @@ def find_egginfo(path=None):
         return find_egginfo(path.dirname())
 
     if len(egginfos) > 1:
-        print >>sys.stderr, 'WARNING: more than one *.egg-info' + \
-            ' directory found.'
+        print('WARNING: more than one *.egg-info directory found.',
+              file=sys.stderr)
         return None
 
     return egginfos[0]

--- a/ftw/upgrade/command/utils.py
+++ b/ftw/upgrade/command/utils.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 from path import Path
-from StringIO import StringIO
+from six import StringIO
 
 import contextlib
 import os

--- a/ftw/upgrade/directory/recorder.py
+++ b/ftw/upgrade/directory/recorder.py
@@ -6,6 +6,8 @@ from zope.component import adapts
 from zope.interface import implements
 from zope.interface import Interface
 
+import six
+
 
 ANNOTATION_KEY = 'ftw.upgrade:recorder'
 
@@ -46,7 +48,7 @@ class UpgradeStepRecorder(object):
         if profilename.startswith('profile-'):
             profilename = profilename[len('profile-'):]
 
-        if not isinstance(profilename, unicode):
+        if not isinstance(profilename, six.text_type):
             profilename = profilename.decode('utf-8')
 
         return profilename

--- a/ftw/upgrade/directory/recorder.py
+++ b/ftw/upgrade/directory/recorder.py
@@ -3,7 +3,7 @@ from ftw.upgrade.interfaces import IUpgradeStepRecorder
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zope.annotation import IAnnotations
 from zope.component import adapts
-from zope.interface import implements
+from zope.interface import implementer
 from zope.interface import Interface
 
 import six
@@ -12,8 +12,8 @@ import six
 ANNOTATION_KEY = 'ftw.upgrade:recorder'
 
 
+@implementer(IUpgradeStepRecorder)
 class UpgradeStepRecorder(object):
-    implements(IUpgradeStepRecorder)
     adapts(IPloneSiteRoot, Interface)
 
     def __init__(self, portal, profilename):

--- a/ftw/upgrade/directory/scaffold.py
+++ b/ftw/upgrade/directory/scaffold.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from path import Path
+
 import inflection
 import os
 import re

--- a/ftw/upgrade/directory/scanner.py
+++ b/ftw/upgrade/directory/scanner.py
@@ -104,4 +104,4 @@ class Scanner(object):
         except ImportError:
             pass
         else:
-            imp.load_module(self.dottedname, fp, pathname, description)
+            imp.load_module(self.dottedname, fp, str(pathname), description)

--- a/ftw/upgrade/directory/scanner.py
+++ b/ftw/upgrade/directory/scanner.py
@@ -11,6 +11,7 @@ import imp
 import inspect
 import os.path
 import re
+import six
 
 
 UPGRADESTEP_DATETIME_REGEX = re.compile(r'^.*/?(\d{14})[^/]*/upgrade.py$')
@@ -89,8 +90,7 @@ class Scanner(object):
                 continue
 
             title = subject_from_docstring(inspect.getdoc(value) or name)
-            if isinstance(title, str):
-                title = title.decode('utf-8')
+            title = six.ensure_text(title)
             yield (title, value)
 
     def _load_upgrades_directory(self):

--- a/ftw/upgrade/directory/scanner.py
+++ b/ftw/upgrade/directory/scanner.py
@@ -1,8 +1,12 @@
 from ftw.upgrade import UpgradeStep
 from ftw.upgrade.exceptions import UpgradeStepDefinitionError
 from ftw.upgrade.utils import subject_from_docstring
+from functools import reduce
 from glob import glob
 from Products.GenericSetup.upgrade import normalize_version
+from six.moves import filter
+from six.moves import map
+
 import imp
 import inspect
 import os.path
@@ -20,16 +24,16 @@ class Scanner(object):
 
     def scan(self):
         self._load_upgrades_directory()
-        infos = map(self._build_upgrade_step_info,
-                    self._find_upgrade_directories())
+        infos = list(map(self._build_upgrade_step_info,
+                         self._find_upgrade_directories()))
         infos.sort(key=lambda info: normalize_version(info['target-version']))
         if len(infos) > 0:
             reduce(self._chain_upgrade_steps, infos)
         return infos
 
     def _find_upgrade_directories(self):
-        return filter(UPGRADESTEP_DATETIME_REGEX.match,
-                      glob('{0}/*/upgrade.py'.format(self.directory)))
+        return list(filter(UPGRADESTEP_DATETIME_REGEX.match,
+                           glob('{0}/*/upgrade.py'.format(self.directory))))
 
     def _build_upgrade_step_info(self, path):
         title, callable = self._load_upgrade_step_code(path)

--- a/ftw/upgrade/directory/subscribers.py
+++ b/ftw/upgrade/directory/subscribers.py
@@ -4,7 +4,9 @@ from ftw.upgrade.interfaces import IUpgradeStepRecorder
 from functools import partial
 from operator import itemgetter
 from Products.CMFCore.utils import getToolByName
+from six.moves import map
 from zope.component import getMultiAdapter
+
 import os
 import re
 
@@ -47,6 +49,6 @@ def profile_installed(event):
     portal = getToolByName(event.tool, 'portal_url').getPortalObject()
     recorder = getMultiAdapter((portal, profile), IUpgradeStepRecorder)
 
-    map(recorder.mark_as_installed,
-        map(itemgetter('sdest'),
-            flatten_upgrades(event.tool.listUpgrades(profile, show_old=True))))
+    list(map(recorder.mark_as_installed, map(
+        itemgetter('sdest'), flatten_upgrades(
+            event.tool.listUpgrades(profile, show_old=True)))))

--- a/ftw/upgrade/directory/zcml.py
+++ b/ftw/upgrade/directory/zcml.py
@@ -13,6 +13,7 @@ from Products.GenericSetup.upgrade import UpgradeStep
 from zope.configuration.fields import Path
 from zope.configuration.fields import Tokens
 from zope.interface import Interface
+
 import os
 import zope.schema
 
@@ -109,8 +110,8 @@ def upgrade_step_directory_action(profile, dottedname, path,
 
 
 def find_start_version(profile):
-    upgrades = _upgrade_registry.getUpgradeStepsForProfile(profile).values()
-    upgrades = sorted(upgrades, key=attrgetter('dest'))
+    upgrades = list(_upgrade_registry.getUpgradeStepsForProfile(profile).values())
+    upgrades.sort(key=attrgetter('dest'))
     if len(upgrades) > 0:
         return upgrades[-1].dest
     else:

--- a/ftw/upgrade/events.py
+++ b/ftw/upgrade/events.py
@@ -1,8 +1,8 @@
 from ftw.upgrade.interfaces import IClassMigratedEvent
 from zope.component.interfaces import ObjectEvent
-from zope.interface import implements
+from zope.interface import implementer
 
 
+@implementer(IClassMigratedEvent)
 class ClassMigratedEvent(ObjectEvent):
-
-    implements(IClassMigratedEvent)
+    pass

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -11,7 +11,6 @@ from ftw.upgrade.utils import format_duration
 from ftw.upgrade.utils import get_sorted_profile_ids
 from ftw.upgrade.utils import optimize_memory_usage
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import get_installer
 from Products.GenericSetup.interfaces import ISetupTool
 from Products.GenericSetup.upgrade import _upgrade_registry
 from zope.component import adapts
@@ -22,6 +21,11 @@ from zope.interface import implementer
 import logging
 import time
 import transaction
+
+try:
+    from Products.CMFPlone.utils import get_installer
+except ImportError:
+    get_installer = None
 
 
 logger = logging.getLogger('ftw.upgrade')
@@ -123,16 +127,17 @@ class Executioner(object):
             profileinfo = self.portal_setup.getProfileInfo(profileid)
         except KeyError:
             return
-
-        quickinstaller = get_installer(
-            self.portal_setup, self.portal_setup.REQUEST)
         product = profileinfo['product']
-        if not quickinstaller.is_product_installed(product):
-            return
 
-        # version = quickinstaller.get_product_version(product)
-        # if version:
-        #     quickinstaller.get(product).installedversion = version
+        if get_installer is None:
+            quickinstaller = getToolByName(self.portal_setup,
+                                           'portal_quickinstaller')
+            if not quickinstaller.isProductInstalled(product):
+                return
+
+            version = quickinstaller.getProductVersion(product)
+            if version:
+                quickinstaller.get(product).installedversion = version
 
     security.declarePrivate('_do_upgrade')
     def _do_upgrade(self, profileid, upgradeid):

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -168,22 +168,12 @@ class Executioner(object):
         portal = portal_url.getPortalObject()
         adapters = list(getAdapters((portal, portal.REQUEST), IPostUpgrade))
 
-        def _sorter(a, b):
-            name_a = a[0]
-            name_b = b[0]
-
-            if name_a not in profile_order and name_b not in profile_order:
-                return 0
-
-            elif name_a not in profile_order:
+        def sort_key(item):
+            name = item[0]
+            if name not in profile_order:
                 return -1
-
-            elif name_b not in profile_order:
-                return 1
-
             else:
-                return cmp(profile_order.index(name_a),
-                           profile_order.index(name_b))
+                return profile_order.index(name)
 
-        adapters.sort(_sorter)
+        adapters.sort(key=sort_key)
         return [adapter for name, adapter in adapters]

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -11,6 +11,7 @@ from ftw.upgrade.utils import format_duration
 from ftw.upgrade.utils import get_sorted_profile_ids
 from ftw.upgrade.utils import optimize_memory_usage
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import get_installer
 from Products.GenericSetup.interfaces import ISetupTool
 from Products.GenericSetup.upgrade import _upgrade_registry
 from zope.component import adapts
@@ -123,15 +124,15 @@ class Executioner(object):
         except KeyError:
             return
 
-        quickinstaller = getToolByName(self.portal_setup,
-                                       'portal_quickinstaller')
+        quickinstaller = get_installer(
+            self.portal_setup, self.portal_setup.REQUEST)
         product = profileinfo['product']
-        if not quickinstaller.isProductInstalled(product):
+        if not quickinstaller.is_product_installed(product):
             return
 
-        version = quickinstaller.getProductVersion(product)
-        if version:
-            quickinstaller.get(product).installedversion = version
+        # version = quickinstaller.get_product_version(product)
+        # if version:
+        #     quickinstaller.get(product).installedversion = version
 
     security.declarePrivate('_do_upgrade')
     def _do_upgrade(self, profileid, upgradeid):

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -16,7 +16,7 @@ from Products.GenericSetup.upgrade import _upgrade_registry
 from zope.component import adapts
 from zope.component import getAdapters
 from zope.interface import alsoProvides
-from zope.interface import implements
+from zope.interface import implementer
 
 import logging
 import time
@@ -26,9 +26,9 @@ import transaction
 logger = logging.getLogger('ftw.upgrade')
 
 
+@implementer(IExecutioner)
 class Executioner(object):
 
-    implements(IExecutioner)
     adapts(ISetupTool)
     security = ClassSecurityInformation()
 

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -17,6 +17,7 @@ from zope.component import adapts
 from zope.component import getAdapters
 from zope.interface import alsoProvides
 from zope.interface import implements
+
 import logging
 import time
 import transaction

--- a/ftw/upgrade/gatherer.py
+++ b/ftw/upgrade/gatherer.py
@@ -15,7 +15,7 @@ from six.moves import map
 from zope.component import adapts
 from zope.component import getMultiAdapter
 from zope.deprecation import deprecated
-from zope.interface import implements
+from zope.interface import implementer
 
 
 def flatten_upgrades(upgrades):
@@ -93,8 +93,8 @@ def extend_auto_upgrades_with_human_formatted_date_version(profiles):
     return profiles
 
 
+@implementer(IUpgradeInformationGatherer)
 class UpgradeInformationGatherer(object):
-    implements(IUpgradeInformationGatherer)
     adapts(ISetupTool)
 
     security = ClassSecurityInformation()

--- a/ftw/upgrade/gatherer.py
+++ b/ftw/upgrade/gatherer.py
@@ -8,6 +8,7 @@ from ftw.upgrade.utils import get_sorted_profile_ids
 from functools import reduce
 from operator import itemgetter
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import get_installer
 from Products.GenericSetup.interfaces import ISetupTool
 from Products.GenericSetup.upgrade import normalize_version
 from Products.GenericSetup.upgrade import UpgradeStep
@@ -234,16 +235,16 @@ class UpgradeInformationGatherer(object):
 
     security.declarePrivate('_is_profile_installed')
     def _is_profile_installed(self, profileid):
-        quickinstaller = getToolByName(self.portal_setup,
-                                       'portal_quickinstaller')
+        quickinstaller = get_installer(self.portal, self.portal.REQUEST)
+
         try:
             profileinfo = self.portal_setup.getProfileInfo(profileid)
         except KeyError:
             return False
 
         product = profileinfo['product']
-        if quickinstaller.isProductInstallable(product) and \
-                not quickinstaller.isProductInstalled(product):
+        if quickinstaller.is_product_installable(product) and \
+                not quickinstaller.is_product_installed(product):
             return False
 
         version = self.portal_setup.getLastVersionForProfile(profileid)

--- a/ftw/upgrade/indexing.py
+++ b/ftw/upgrade/indexing.py
@@ -1,5 +1,6 @@
 import pkg_resources
 
+
 HAS_INDEXING = False
 
 try:

--- a/ftw/upgrade/interfaces.py
+++ b/ftw/upgrade/interfaces.py
@@ -4,7 +4,8 @@
 
 
 from zope.component.interfaces import IObjectEvent
-from zope.interface import Interface, Attribute
+from zope.interface import Attribute
+from zope.interface import Interface
 
 
 class IUpgradeLayer(Interface):

--- a/ftw/upgrade/intid/migrate.py
+++ b/ftw/upgrade/intid/migrate.py
@@ -1,5 +1,5 @@
-from zope.intid.interfaces import IIntIds
 from zope.component import queryUtility
+from zope.intid.interfaces import IIntIds
 
 
 def update_intids_after_class_migration(event):

--- a/ftw/upgrade/jsonapi/base.py
+++ b/ftw/upgrade/jsonapi/base.py
@@ -7,6 +7,7 @@ from ftw.upgrade.jsonapi.utils import jsonify
 from zope.interface import implements
 from zope.publisher.browser import BrowserView
 from zope.publisher.interfaces import IPublishTraverse
+
 import re
 
 

--- a/ftw/upgrade/jsonapi/base.py
+++ b/ftw/upgrade/jsonapi/base.py
@@ -4,15 +4,15 @@ from ftw.upgrade.jsonapi.utils import action
 from ftw.upgrade.jsonapi.utils import ErrorHandling
 from ftw.upgrade.jsonapi.utils import get_action_discovery_information
 from ftw.upgrade.jsonapi.utils import jsonify
-from zope.interface import implements
+from zope.interface import implementer
 from zope.publisher.browser import BrowserView
 from zope.publisher.interfaces import IPublishTraverse
 
 import re
 
 
+@implementer(IPublishTraverse)
 class APIView(BrowserView):
-    implements(IPublishTraverse)
     api_version = 'v1'
 
     def __init__(self, *args, **kwargs):

--- a/ftw/upgrade/jsonapi/utils.py
+++ b/ftw/upgrade/jsonapi/utils.py
@@ -206,7 +206,7 @@ def perform_tempfile_authentication(context, request):
 
 
 def validate_tempfile_authentication_header_value(header_value):
-    if not re.match('^tmp\w{6}:\w{64}', header_value):
+    if not re.match('^tmp\w{6,8}:\w{64}', header_value):
         raise ValueError(
             'tempfile auth: invalid x-ftw.upgrade-tempfile-auth header value.')
 

--- a/ftw/upgrade/jsonapi/utils.py
+++ b/ftw/upgrade/jsonapi/utils.py
@@ -3,6 +3,7 @@ from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import SpecialUsers
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from binascii import hexlify
 from ftw.upgrade.exceptions import CyclicDependencies
 from ftw.upgrade.exceptions import UpgradeNotFound
 from ftw.upgrade.jsonapi.exceptions import AbortTransactionWithStreamedResponse
@@ -235,7 +236,7 @@ def get_system_upgrade_user(context):
     acl_users = context.acl_users
     if not acl_users.getUserById('system-upgrade'):
         acl_users.userFolderAddUser(
-            'system-upgrade', os.urandom(16).encode('hex'), ['Manager'], None)
+            'system-upgrade', hexlify(os.urandom(16)), ['Manager'], None)
     return acl_users.getUserById('system-upgrade')
 
 

--- a/ftw/upgrade/jsonapi/utils.py
+++ b/ftw/upgrade/jsonapi/utils.py
@@ -17,6 +17,7 @@ from OFS.interfaces import IApplication
 from zExceptions import Unauthorized
 from zope.interface import alsoProvides
 from zope.security import checkPermission
+
 import inspect
 import json
 import os

--- a/ftw/upgrade/jsonapi/utils.py
+++ b/ftw/upgrade/jsonapi/utils.py
@@ -126,7 +126,7 @@ def jsonify(func):
             return result
 
         response.setHeader('Content-Type', 'application/json; charset=utf-8')
-        return json.dumps(result, indent=4, encoding='utf-8') + '\n'
+        return json.dumps(result, indent=4) + '\n'
 
     json_wrapper.__doc__ = func.__doc__
     json_wrapper.__name__ = func.__name__

--- a/ftw/upgrade/migration.py
+++ b/ftw/upgrade/migration.py
@@ -6,7 +6,6 @@ from ftw.upgrade.helpers import update_security_for
 from functools import partial
 from operator import methodcaller
 from persistent.mapping import PersistentMapping
-from plone.app.blob.interfaces import IBlobWrapper
 from plone.app.relationfield.event import extract_relations
 from plone.app.textfield import IRichText
 from plone.app.textfield import IRichTextValue
@@ -19,8 +18,6 @@ from plone.namedfile.interfaces import INamedBlobImageField
 from plone.namedfile.interfaces import INamedField
 from plone.uuid.interfaces import IMutableUUID
 from plone.uuid.interfaces import IUUID
-from Products.Archetypes.interfaces import IBaseObject
-from Products.Archetypes.interfaces import IComputedField
 from Products.CMFPlone.interfaces import constrains
 from Products.CMFPlone.utils import getFSVersionTuple
 from six.moves import filter
@@ -42,6 +39,26 @@ import logging
 import pkg_resources
 import six
 
+
+try:
+    pkg_resources.get_distribution('Products.Archetypes')
+except pkg_resources.DistributionNotFound:
+    class IBaseObject(Interface):
+        pass
+
+    class IComputedField(Interface):
+        pass
+else:
+    from Products.Archetypes.interfaces import IBaseObject
+    from Products.Archetypes.interfaces import IComputedField
+
+try:
+    pkg_resources.get_distribution('plone.app.blob')
+except pkg_resources.DistributionNotFound:
+    class IBlobWrapper(Interface):
+        pass
+else:
+    from plone.app.blob.interfaces import IBlobWrapper
 
 try:
     pkg_resources.get_distribution('archetypes.referencebrowserwidget')

--- a/ftw/upgrade/placefulworkflow.py
+++ b/ftw/upgrade/placefulworkflow.py
@@ -1,5 +1,6 @@
-from Products.CMFCore.utils import getToolByName
 from ftw.upgrade.workflow import WorkflowChainUpdater
+from Products.CMFCore.utils import getToolByName
+
 import logging
 
 

--- a/ftw/upgrade/progresslogger.py
+++ b/ftw/upgrade/progresslogger.py
@@ -1,6 +1,8 @@
 from AccessControl.SecurityInfo import ClassSecurityInformation
 from time import time
+
 import logging
+import six
 
 
 class ProgressLogger(object):
@@ -16,7 +18,7 @@ class ProgressLogger(object):
         self.message = message
         self.iterable = iterable
 
-        if isinstance(iterable, (int, long, float)):
+        if isinstance(iterable, (six.integer_types + (float,))):
             self.length = iterable
         else:
             self.length = len(iterable)

--- a/ftw/upgrade/resource_registries.py
+++ b/ftw/upgrade/resource_registries.py
@@ -6,8 +6,9 @@ from zope.component.hooks import getSite
 
 def recook_resources():
     for name in ('portal_css', 'portal_javascripts'):
-        registry = getToolByName(getSite(), name)
-        registry.cookResources()
+        registry = getToolByName(getSite(), name, None)
+        if registry is not None:
+            registry.cookResources()
 
     # Plone 5: clear all bundles
     registry = getUtility(IRegistry)

--- a/ftw/upgrade/resource_registries.py
+++ b/ftw/upgrade/resource_registries.py
@@ -11,8 +11,7 @@ def recook_resources():
 
     # Plone 5: clear all bundles
     registry = getUtility(IRegistry)
-    for key in filter(
-            lambda key: (key.startswith('plone.bundles/')
-                         and key.endswith('.last_compilation')),
-            registry.records.keys()):
+    for key in [key for key in registry.records.keys()
+                if (key.startswith('plone.bundles/')
+                    and key.endswith('.last_compilation'))]:
         registry[key] = None

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -15,6 +15,7 @@ from plone.portlets.interfaces import IPortletManagerRenderer
 from Products.BTreeFolder2.BTreeFolder2 import BTreeFolder2Base
 from Products.CMFCore.ActionInformation import ActionInformation
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import get_installer
 from Products.ZCatalog.ProgressHandler import ZLogHandler
 from zExceptions import NotFound
 from zope.browser.interfaces import IBrowserView
@@ -343,16 +344,16 @@ class UpgradeStep(object):
     def is_product_installed(self, product_name):
         """Check whether a product is installed.
         """
-        quickinstaller = self.getToolByName('portal_quickinstaller')
-        return quickinstaller.isProductInstallable(product_name) and \
-            quickinstaller.isProductInstalled(product_name)
+        quickinstaller = get_installer(self.portal, self.portal.REQUEST)
+        return quickinstaller.is_product_installable(product_name) and \
+            quickinstaller.is_product_installed(product_name)
 
     security.declarePrivate('uninstall_product')
     def uninstall_product(self, product_name):
         """Uninstalls a product using the quick installer.
         """
-        quickinstaller = self.getToolByName('portal_quickinstaller')
-        quickinstaller.uninstallProducts([product_name])
+        quickinstaller = get_installer(self.portal, self.portal.REQUEST)
+        quickinstaller.uninstall_product(product_name)
 
     security.declarePrivate('migrate_class')
     def migrate_class(self, obj, new_class):

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -21,7 +21,7 @@ from zope.browser.interfaces import IBrowserView
 from zope.event import notify
 from zope.interface import directlyProvidedBy
 from zope.interface import directlyProvides
-from zope.interface import implements
+from zope.interface import implementer
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IBrowserRequest
 
@@ -39,8 +39,8 @@ except ImportError:
 LOG = logging.getLogger('ftw.upgrade')
 
 
+@implementer(IUpgradeStep)
 class UpgradeStep(object):
-    implements(IUpgradeStep)
     security = ClassSecurityInformation()
 
     deferrable = False

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -1,5 +1,6 @@
 from AccessControl.SecurityInfo import ClassSecurityInformation
-from Acquisition import aq_base, aq_parent
+from Acquisition import aq_base
+from Acquisition import aq_parent
 from ftw.upgrade.events import ClassMigratedEvent
 from ftw.upgrade.exceptions import NoAssociatedProfileError
 from ftw.upgrade.helpers import update_security_for
@@ -23,8 +24,10 @@ from zope.interface import directlyProvides
 from zope.interface import implements
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IBrowserRequest
+
 import logging
 import re
+import six
 
 
 try:
@@ -454,7 +457,7 @@ class UpgradeStep(object):
         """
 
         if getattr(workflow_names, '__iter__', None) is None or \
-                isinstance(workflow_names, (str, unicode)):
+                isinstance(workflow_names, (str, six.text_type)):
             raise ValueError(
                 '"workflows" must be a list of workflow names.')
 

--- a/ftw/upgrade/testing.py
+++ b/ftw/upgrade/testing.py
@@ -16,8 +16,10 @@ from plone.testing import z2
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import getFSVersionTuple
 from Products.SiteAccess.VirtualHostMonster import manage_addVirtualHostMonster
+from six.moves import map
 from zope.component import getUtility
 from zope.configuration import xmlconfig
+
 import ftw.upgrade.tests.builders
 import pkg_resources
 import transaction
@@ -119,7 +121,7 @@ class UpgradeLayer(PloneSandboxLayer):
         portal_setup = getToolByName(portal, 'portal_setup')
         profileid = 'plone.app.jquery:default'
         version = max(map(itemgetter('dest'),
-                          portal_setup.listUpgrades(profileid, show_old=True)))
+                      portal_setup.listUpgrades(profileid, show_old=True)))
         portal_setup.setLastVersionForProfile(profileid, version)
 
 

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -244,7 +244,7 @@ class WorkflowTestCase(TestCase):
             review_state = wftool.getInfoFor(obj, 'review_state')
             got[obj] = review_state
 
-        self.assertEquals(
+        self.assertEqual(
             expected, got, 'Unexpected workflow states')
 
     def set_workflow_chain(self, for_type, to_workflow):
@@ -255,7 +255,7 @@ class WorkflowTestCase(TestCase):
     def assertSecurityIsUpToDate(self):
         wftool = getToolByName(self.portal, 'portal_workflow')
         updated_objects = wftool.updateRoleMappings()
-        self.assertEquals(
+        self.assertEqual(
             0, updated_objects,
             'Expected all objects to have an up to date security, but'
             ' there were some which were not up to date.')

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -22,17 +22,23 @@ from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_PASSWORD
 from Products.CMFCore.utils import getToolByName
+from six.moves import map
+from six.moves import zip
 from StringIO import StringIO
 from unittest import TestCase
 from zope.component import getMultiAdapter
 from zope.component import queryAdapter
+
 import json
 import logging
 import lxml.html
 import os
 import re
+import six
+import six.moves.urllib.error
+import six.moves.urllib.parse
+import six.moves.urllib.request
 import transaction
-import urllib
 
 
 class UpgradeTestCase(TestCase):
@@ -103,14 +109,17 @@ class UpgradeTestCase(TestCase):
     def install_profile(self, profileid, version=None):
         self.portal_setup.runAllImportStepsFromProfile('profile-{0}'.format(profileid))
         if version is not None:
-            self.portal_setup.setLastVersionForProfile(profileid, (unicode(version),))
+            self.portal_setup.setLastVersionForProfile(
+                profileid, (six.text_type(version),))
         transaction.commit()
 
     def install_profile_upgrades(self, *profileids):
         gatherer = queryAdapter(self.portal_setup, IUpgradeInformationGatherer)
-        upgrade_info = [(profile['id'], map(itemgetter('id'), profile['upgrades']))
-                        for profile in gatherer.get_upgrades()
-                        if profile['id'] in profileids]
+        upgrade_info = [
+            (profile['id'], list(map(itemgetter('id'), profile['upgrades'])))
+            for profile in gatherer.get_upgrades()
+            if profile['id'] in profileids
+        ]
         executioner = queryAdapter(self.portal_setup, IExecutioner)
         executioner.install(upgrade_info)
 
@@ -118,7 +127,7 @@ class UpgradeTestCase(TestCase):
         profile = re.sub('^profile-', '', profile)
         recorder = getMultiAdapter((self.portal, profile), IUpgradeStepRecorder)
         recorder.clear()
-        map(recorder.mark_as_installed, destinations)
+        list(map(recorder.mark_as_installed, destinations))
         transaction.commit()
 
     def clear_recorded_upgrades(self, profile):
@@ -147,7 +156,7 @@ class UpgradeTestCase(TestCase):
         self.assertDictEqual(
             expected, got,
             'Unexpected gatherer result.\n\nPackages in result {0}:'.format(
-                map(lambda profile: profile['id'], result)))
+                [profile['id'] for profile in result]))
 
     def asset(self, filename):
         return Path(__file__).dirname().joinpath('assets', filename).text()
@@ -156,10 +165,9 @@ class UpgradeTestCase(TestCase):
     def assert_resources_recooked(self):
         def get_resources():
             doc = lxml.html.fromstring(self.portal())
-            return map(str.strip,
-                       map(lxml.html.tostring,
-                           doc.xpath('//link[@rel="stylesheet"][@href]'
-                                     ' | //script[@src]')))
+            return list(map(str.strip, map(lxml.html.tostring,
+                            doc.xpath('//link[@rel="stylesheet"][@href]'
+                                      ' | //script[@src]'))))
 
         resources = get_resources()
         yield
@@ -291,11 +299,10 @@ class WorkflowTestCase(TestCase):
                 msg and (' (%s)' % msg) or ''))
 
     def get_not_acquired_permissions_of(self, obj):
-        acquired_permissions = filter(
-            lambda item: not item.get('acquire'),
-            obj.permission_settings())
+        acquired_permissions = [
+            item for item in obj.permission_settings() if not item.get('acquire')]
 
-        return map(lambda item: item.get('name'), acquired_permissions)
+        return [item.get('name') for item in acquired_permissions]
 
 
 class JsonApiTestCase(UpgradeTestCase):
@@ -335,8 +342,7 @@ class JsonApiTestCase(UpgradeTestCase):
         with verbose_logging():
             if method.lower() == 'get':
                 browser.visit(context, view='upgrades-api/{0}?{1}'.format(
-                        action,
-                        urllib.urlencode(data)))
+                    action, six.moves.urllib.parse.urlencode(data)))
 
             elif method.lower() == 'post':
                 if not data:

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -182,7 +182,7 @@ class UpgradeTestCase(TestCase):
             timestamp_file = self.portal.portal_resources.resource_overrides.production['timestamp.txt']
             # The data contains text, which should be a DateTime.
             # Convert it to an actual DateTime object so we can be sure when comparing it.
-            return DateTime(timestamp_file.data)
+            return DateTime(timestamp_file.data.decode('utf8'))
 
         timestamp = get_timestamp()
         yield

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -22,9 +22,9 @@ from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_PASSWORD
 from Products.CMFCore.utils import getToolByName
+from six import StringIO
 from six.moves import map
 from six.moves import zip
-from StringIO import StringIO
 from unittest import TestCase
 from zope.component import getMultiAdapter
 from zope.component import queryAdapter

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -165,9 +165,9 @@ class UpgradeTestCase(TestCase):
     def assert_resources_recooked(self):
         def get_resources():
             doc = lxml.html.fromstring(self.portal())
-            return list(map(str.strip, map(lxml.html.tostring,
+            return list(map(str.strip, map(six.ensure_str, map(lxml.html.tostring,
                             doc.xpath('//link[@rel="stylesheet"][@href]'
-                                      ' | //script[@src]'))))
+                                      ' | //script[@src]')))))
 
         resources = get_resources()
         yield

--- a/ftw/upgrade/tests/builders.py
+++ b/ftw/upgrade/tests/builders.py
@@ -3,6 +3,7 @@ from ftw.builder.utils import serialize_callable
 from ftw.upgrade import UpgradeStep
 from ftw.upgrade.directory import scaffold
 from path import Path
+
 import inflection
 import os
 

--- a/ftw/upgrade/tests/helpers.py
+++ b/ftw/upgrade/tests/helpers.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+
 import logging
 import os
 import sys

--- a/ftw/upgrade/tests/test_command.py
+++ b/ftw/upgrade/tests/test_command.py
@@ -1,4 +1,5 @@
 from ftw.upgrade.tests.base import CommandTestCase
+
 import os
 
 

--- a/ftw/upgrade/tests/test_command_combine_bundles.py
+++ b/ftw/upgrade/tests/test_command_combine_bundles.py
@@ -1,6 +1,7 @@
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
 from Products.CMFPlone.utils import getFSVersionTuple
 from unittest import skipIf
+
 import transaction
 
 

--- a/ftw/upgrade/tests/test_command_create.py
+++ b/ftw/upgrade/tests/test_command_create.py
@@ -2,6 +2,8 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.upgrade.tests.base import CommandTestCase
 
+import six
+
 
 class TestCreateCommand(CommandTestCase):
 
@@ -20,7 +22,7 @@ class TestCreateCommand(CommandTestCase):
                 upgrades_dir.listdir()))
 
         step_path, = upgrades_dir.listdir()
-        self.assertRegexpMatches(step_path.name, r'^\d{14}_add_controlpanel_action$')
+        six.assertRegex(self, step_path.name, r'^\d{14}_add_controlpanel_action$')
 
         code_path = step_path.joinpath('upgrade.py')
         self.assertTrue(code_path.exists(), 'upgrade.py is missing')
@@ -62,8 +64,8 @@ class TestCreateCommand(CommandTestCase):
 
         upgrades_dir = package.package_path.joinpath('upgrades')
         step_path, = upgrades_dir.listdir()
-        self.assertRegexpMatches(step_path.name,
-                                 r'^\d{14}_update_ftw_upgrade_to_version_3$')
+        six.assertRegex(
+            self, step_path.name, r'^\d{14}_update_ftw_upgrade_to_version_3$')
 
         code_path = step_path.joinpath('upgrade.py')
         self.assertTrue(code_path.exists(), 'upgrade.py is missing')

--- a/ftw/upgrade/tests/test_command_fake_terminal.py
+++ b/ftw/upgrade/tests/test_command_fake_terminal.py
@@ -12,41 +12,41 @@ class TestFakeTerminal(TestCase):
 
     def test_concatenating_colors(self):
         term = FakeTerminal()
-        self.assertEquals(
+        self.assertEqual(
             'foo',
             term.standout + term.green + term.red_bold + 'foo' + term.normal)
 
     def test_calling_colors(self):
         term = FakeTerminal()
-        self.assertEquals(
+        self.assertEqual(
             'foo',
             term.red_bold(term.standout('foo')))
 
     def test_length(self):
-        self.assertEquals(3, FakeTerminal().length('foo'))
+        self.assertEqual(3, FakeTerminal().length('foo'))
 
     def test_ljust(self):
-        self.assertEquals(TERMINAL.ljust('foo', 10),
-                          FakeTerminal().ljust('foo', 10))
-        self.assertEquals(TERMINAL.ljust(u'foo', 10),
-                          FakeTerminal().ljust(u'foo', 10))
+        self.assertEqual(TERMINAL.ljust('foo', 10),
+                         FakeTerminal().ljust('foo', 10))
+        self.assertEqual(TERMINAL.ljust(u'foo', 10),
+                         FakeTerminal().ljust(u'foo', 10))
 
     def test_rjust(self):
-        self.assertEquals(TERMINAL.rjust('foo', 10),
-                          FakeTerminal().rjust('foo', 10))
+        self.assertEqual(TERMINAL.rjust('foo', 10),
+                         FakeTerminal().rjust('foo', 10))
 
     def test_center(self):
-        self.assertEquals(TERMINAL.center('foo', 10),
-                          FakeTerminal().center('foo', 10))
+        self.assertEqual(TERMINAL.center('foo', 10),
+                         FakeTerminal().center('foo', 10))
 
     def test_strip(self):
-        self.assertEquals(TERMINAL.strip('  foo  '),
-                          FakeTerminal().strip('  foo  '))
+        self.assertEqual(TERMINAL.strip('  foo  '),
+                         FakeTerminal().strip('  foo  '))
 
     def test_rstrip(self):
-        self.assertEquals(TERMINAL.rstrip('  foo  '),
-                          FakeTerminal().rstrip('  foo  '))
+        self.assertEqual(TERMINAL.rstrip('  foo  '),
+                         FakeTerminal().rstrip('  foo  '))
 
     def test_lstrip(self):
-        self.assertEquals(TERMINAL.lstrip('  foo  '),
-                          FakeTerminal().lstrip('  foo  '))
+        self.assertEqual(TERMINAL.lstrip('  foo  '),
+                         FakeTerminal().lstrip('  foo  '))

--- a/ftw/upgrade/tests/test_command_install.py
+++ b/ftw/upgrade/tests/test_command_install.py
@@ -35,7 +35,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
 
             self.assertFalse(self.is_installed('the.package:default', datetime(2011, 1, 1)))
             exitcode, output = self.upgrade_script('install -s plone --proposed')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
             transaction.begin()  # sync transaction
             self.assertTrue(self.is_installed('the.package:default', datetime(2011, 1, 1)))
             self.assertIn('Result: SUCCESS', output)
@@ -53,7 +53,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
 
             self.assertFalse(self.is_installed('the.package:default', datetime(2011, 1, 1)))
             exitcode, output = self.upgrade_script('install -s plone --proposed --skip-deferrable')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
             transaction.begin()  # sync transaction
             self.assertFalse(self.is_installed('the.package:default', datetime(2011, 1, 1)))
             self.assertIn('Result: SUCCESS', output)
@@ -71,7 +71,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
 
             self.assertFalse(self.is_installed('the.package:default', datetime(2011, 1, 1)))
             exitcode, output = self.upgrade_script('install -s plone --proposed')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
             transaction.begin()  # sync transaction
             self.assertTrue(self.is_installed('the.package:default', datetime(2011, 1, 1)))
             self.assertIn('Result: SUCCESS', output)
@@ -91,7 +91,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
             with no_logging_threads():
                 exitcode, output = self.upgrade_script('install -s plone --proposed',
                                                        assert_exitcode=False)
-            self.assertEquals(3, exitcode)
+            self.assertEqual(3, exitcode)
             self.assertIn('Result: FAILURE', output)
 
     def test_umlauts_can_be_printed(self):
@@ -132,7 +132,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
                 if changed_defaultencoding:
                     sys.setdefaultencoding(system_encoding)
 
-            self.assertEquals(0, exitcode, output)
+            self.assertEqual(0, exitcode, output)
 
     def test_install_list_of_upgrades(self):
         self.package.with_profile(
@@ -147,7 +147,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
             self.assertFalse(self.is_installed('the.package:default', datetime(2011, 1, 1)))
             exitcode, output = self.upgrade_script(
                 'install -s plone --upgrades 20110101000000@the.package:default')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
             transaction.begin()  # sync transaction
             self.assertTrue(self.is_installed('the.package:default', datetime(2011, 1, 1)))
             self.assertIn('Result: SUCCESS', output)
@@ -167,7 +167,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
             self.assertFalse(self.is_installed('the.package:default', datetime(2011, 2, 2)))
             exitcode, output = self.upgrade_script(
                 'install -s plone --proposed the.package:default')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
             transaction.begin()  # sync transaction
             self.assertTrue(self.is_installed('the.package:default', datetime(2011, 1, 1)))
             self.assertTrue(self.is_installed('the.package:default', datetime(2011, 2, 2)))
@@ -177,7 +177,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
         exitcode, output = self.upgrade_script(
             'install -s plone --proposed the.inexisting.package:default',
             assert_exitcode=False)
-        self.assertEquals(1, exitcode)
+        self.assertEqual(1, exitcode)
         self.assertIn('ERROR:', output)
 
     def test_virtual_host_monster_is_configured_by_environment_variable(self):
@@ -200,10 +200,10 @@ class TestInstallCommand(CommandAndInstanceTestCase):
         with self.package_created():
             self.install_profile('the.package:default', version='1')
             exitcode, output = self.upgrade_script('install -s plone --proposed')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
             transaction.begin()  # sync transaction
-            self.assertEquals(['https://foo.bar.com/baz/the-folder'],
-                              self.layer['portal'].upgrade_info)
+            self.assertEqual(['https://foo.bar.com/baz/the-folder'],
+                             self.layer['portal'].upgrade_info)
 
     def test_install_profiles(self):
         self.package.with_profile(Builder('genericsetup profile'))
@@ -212,7 +212,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
         with self.package_created():
             exitcode, output = self.upgrade_script(
                 'install -s plone --profiles the.package:default')
-            self.assertEquals(
+            self.assertEqual(
                 [u'ftw.upgrade: Installing profile the.package:default.',
                  u'ftw.upgrade: Done installing profile the.package:default.',
                  u'Result: SUCCESS'],
@@ -223,7 +223,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
         self.purge_log()
         exitcode, output = self.upgrade_script(
             'install -s plone --profiles ftw.upgrade:default')
-        self.assertEquals(
+        self.assertEqual(
             [u'ftw.upgrade: Ignoring already installed profile'
              u' ftw.upgrade:default.',
              u'Result: SUCCESS'],
@@ -234,7 +234,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
         self.purge_log()
         exitcode, output = self.upgrade_script(
             'install -s plone --force --profiles ftw.upgrade:default')
-        self.assertEquals(
+        self.assertEqual(
             [u'ftw.upgrade: Installing profile ftw.upgrade:default.',
              u'ftw.upgrade: Done installing profile ftw.upgrade:default.',
              u'Result: SUCCESS'],
@@ -244,7 +244,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
         exitcode, output = self.upgrade_script(
             'install -s plone --force --upgrades 20110101000000@the.package:default',
             assert_exitcode=False)
-        self.assertEquals(3, exitcode)
-        self.assertEquals(
+        self.assertEqual(3, exitcode)
+        self.assertEqual(
             [u'ERROR: --force can only be used with --profiles.'],
             output.splitlines())

--- a/ftw/upgrade/tests/test_command_install.py
+++ b/ftw/upgrade/tests/test_command_install.py
@@ -6,6 +6,7 @@ from ftw.upgrade.tests.helpers import no_logging_threads
 from persistent.list import PersistentList
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
+
 import os
 import sys
 import transaction

--- a/ftw/upgrade/tests/test_command_jsonapi.py
+++ b/ftw/upgrade/tests/test_command_jsonapi.py
@@ -11,6 +11,8 @@ from plone.app.testing import TEST_USER_PASSWORD
 from Products.CMFPlone.utils import safe_unicode
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import HTTPError
+from six.moves import map
+
 import os
 
 

--- a/ftw/upgrade/tests/test_command_jsonapi.py
+++ b/ftw/upgrade/tests/test_command_jsonapi.py
@@ -161,41 +161,41 @@ class TestJsonAPIUtils(CommandAndInstanceTestCase):
         zconf = ZopeConfPathStub('<http-server>',
                                  '  address 8080',
                                  '</http-server>')
-        self.assertEquals(8080, get_instance_port(zconf))
+        self.assertEqual(8080, get_instance_port(zconf))
 
     def test_get_instance_port_localhost_interface_prefix(self):
         zconf = ZopeConfPathStub('<http-server>',
                                  '  address 127.0.0.1:8080',
                                  '</http-server>')
-        self.assertEquals(8080, get_instance_port(zconf))
+        self.assertEqual(8080, get_instance_port(zconf))
 
     def test_get_instance_port_public_interface_prefix(self):
         zconf = ZopeConfPathStub('<http-server>',
                                  '  address 127.0.0.1:8080',
                                  '</http-server>')
-        self.assertEquals(8080, get_instance_port(zconf))
+        self.assertEqual(8080, get_instance_port(zconf))
 
     def test_get_instance_port_localhost_ip(self):
         zconf = ZopeConfPathStub('ip-address 127.0.0.1',
                                  '<http-server>',
                                  '  address 127.0.0.1:8080',
                                  '</http-server>')
-        self.assertEquals(8080, get_instance_port(zconf))
+        self.assertEqual(8080, get_instance_port(zconf))
 
     def test_get_instance_port_public_ip(self):
         zconf = ZopeConfPathStub('ip-address 0.0.0.0',
                                  '<http-server>',
                                  '  address 127.0.0.1:8080',
                                  '</http-server>')
-        self.assertEquals(8080, get_instance_port(zconf))
+        self.assertEqual(8080, get_instance_port(zconf))
 
     def test_get_instance_port_no_indent(self):
         zconf = ZopeConfPathStub('<http-server>',
                                  'address 8080',
                                  '</http-server>')
-        self.assertEquals(8080, get_instance_port(zconf))
+        self.assertEqual(8080, get_instance_port(zconf))
 
     def test_get_instance_port_not_found(self):
         zconf = ZopeConfPathStub('<http-server>',
                                  '</http-server>')
-        self.assertEquals(None, get_instance_port(zconf))
+        self.assertEqual(None, get_instance_port(zconf))

--- a/ftw/upgrade/tests/test_command_list.py
+++ b/ftw/upgrade/tests/test_command_list.py
@@ -1,8 +1,11 @@
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
+from six.moves import map
+
 import json
 import re
+import six
 
 
 class TestListCommand(CommandAndInstanceTestCase):
@@ -27,8 +30,8 @@ class TestListCommand(CommandAndInstanceTestCase):
             exitcode, output = self.upgrade_script('list --profiles -s plone')
             self.assertEquals(0, exitcode)
 
-            normalized_output = map(unicode.strip,
-                                    re.sub(r' +', ' ', output).splitlines())
+            normalized_output = list(map(six.text_type.strip,
+                                         re.sub(r' +', ' ', output).splitlines()))
             self.assertIn('Installed profiles:', normalized_output)
             self.assertIn('the.package:default'
                           ' 2 proposed 1 orphan'
@@ -240,7 +243,7 @@ class TestListCommand(CommandAndInstanceTestCase):
             decoded = json.loads(output)
             self.assertEqual(len(decoded), 1)
             # The Plone site id is used as key.
-            self.assertEqual(decoded.keys(), ['/plone'])
+            self.assertEqual(list(decoded.keys()), ['/plone'])
             self.assertTrue(isinstance(decoded['/plone'], list))
 
     def test_all_sites_argument_no_json(self):

--- a/ftw/upgrade/tests/test_command_list.py
+++ b/ftw/upgrade/tests/test_command_list.py
@@ -28,7 +28,7 @@ class TestListCommand(CommandAndInstanceTestCase):
             self.clear_recorded_upgrades('the.package:default')
 
             exitcode, output = self.upgrade_script('list --profiles -s plone')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
 
             normalized_output = list(map(six.text_type.strip,
                                          re.sub(r' +', ' ', output).splitlines()))
@@ -50,7 +50,7 @@ class TestListCommand(CommandAndInstanceTestCase):
             self.clear_recorded_upgrades('the.package:default')
 
             exitcode, output = self.upgrade_script('list --profiles -s plone --json')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
             self.assert_json_contains_profile(
                 {'id': 'the.package:default',
                  'title': 'the.package',
@@ -91,7 +91,7 @@ class TestListCommand(CommandAndInstanceTestCase):
             self.clear_recorded_upgrades('the.package:default')
 
             exitcode, output = self.upgrade_script('list --upgrades -s plone')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
             self.assertMultiLineEqual(
                 'Proposed upgrades:\n'
                 'ID:                                        Title:    \n'
@@ -110,7 +110,7 @@ class TestListCommand(CommandAndInstanceTestCase):
             self.clear_recorded_upgrades('the.package:default')
 
             exitcode, output = self.upgrade_script('list --upgrades -s plone --json')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
             self.assert_json_equal(
                 [{
                         "dest": "20110101000000",
@@ -148,7 +148,7 @@ class TestListCommand(CommandAndInstanceTestCase):
             self.clear_recorded_upgrades('the.package:default')
 
             exitcode, output = self.upgrade_script('list --upgrades -s plone')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
 
             self.assertMultiLineEqual(
                 u'Proposed upgrades:\n'
@@ -167,7 +167,7 @@ class TestListCommand(CommandAndInstanceTestCase):
             self.clear_recorded_upgrades('the.package:default')
 
             exitcode, output = self.upgrade_script('list --upgrades -s plone')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
             self.assertMultiLineEqual(
                 'Proposed upgrades:\n'
                 'ID:                                            Title:             \n'
@@ -187,7 +187,7 @@ class TestListCommand(CommandAndInstanceTestCase):
             self.clear_recorded_upgrades('the.package:default')
 
             exitcode, output = self.upgrade_script('list --upgrades -s plone --json')
-            self.assertEquals(0, exitcode)
+            self.assertEqual(0, exitcode)
             self.assert_json_equal(
                 [{
                         "dest": "20110101000000",

--- a/ftw/upgrade/tests/test_command_plone_upgrade.py
+++ b/ftw/upgrade/tests/test_command_plone_upgrade.py
@@ -6,6 +6,7 @@ from Products.CMFPlone.utils import getFSVersionTuple
 from unittest import skipIf
 from ZPublisher.BaseRequest import RequestContainer
 from ZPublisher.HTTPRequest import HTTPRequest
+
 import transaction
 
 

--- a/ftw/upgrade/tests/test_command_plone_upgrade.py
+++ b/ftw/upgrade/tests/test_command_plone_upgrade.py
@@ -22,7 +22,7 @@ class TestPloneUpgradeCommand(CommandAndInstanceTestCase):
     def test_plone_upgrade_already_uptodate(self):
         exitcode, output = self.upgrade_script(
             'plone_upgrade -s plone')
-        self.assertEquals(0, exitcode)
+        self.assertEqual(0, exitcode)
         transaction.begin()  # sync transaction
         self.assertIn(u'Plone Site was already up to date.', output)
 
@@ -35,7 +35,7 @@ class TestPloneUpgradeCommand(CommandAndInstanceTestCase):
 
         exitcode, output = self.upgrade_script(
             'plone_upgrade -s plone')
-        self.assertEquals(0, exitcode)
+        self.assertEqual(0, exitcode)
         transaction.begin()  # sync transaction
         self.assertIn(u'Plone Site has been updated.', output)
 

--- a/ftw/upgrade/tests/test_command_plone_upgrade_needed.py
+++ b/ftw/upgrade/tests/test_command_plone_upgrade_needed.py
@@ -1,6 +1,7 @@
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.factory import _DEFAULT_PROFILE
+
 import transaction
 
 

--- a/ftw/upgrade/tests/test_command_plone_upgrade_needed.py
+++ b/ftw/upgrade/tests/test_command_plone_upgrade_needed.py
@@ -17,7 +17,7 @@ class TestPloneUpgradeNeededCommand(CommandAndInstanceTestCase):
     def test_plone_upgrade_already_uptodate(self):
         exitcode, output = self.upgrade_script(
             'plone_upgrade_needed -s plone')
-        self.assertEquals(0, exitcode)
+        self.assertEqual(0, exitcode)
         self.assertIn(u'false', output)
 
     def test_plone_upgrade_needed(self):
@@ -27,5 +27,5 @@ class TestPloneUpgradeNeededCommand(CommandAndInstanceTestCase):
 
         exitcode, output = self.upgrade_script(
             'plone_upgrade_needed -s plone')
-        self.assertEquals(0, exitcode)
+        self.assertEqual(0, exitcode)
         self.assertIn(u'true', output)

--- a/ftw/upgrade/tests/test_command_recook.py
+++ b/ftw/upgrade/tests/test_command_recook.py
@@ -1,4 +1,5 @@
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
+
 import transaction
 
 

--- a/ftw/upgrade/tests/test_command_sites.py
+++ b/ftw/upgrade/tests/test_command_sites.py
@@ -1,4 +1,5 @@
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
+
 import json
 
 

--- a/ftw/upgrade/tests/test_command_sites.py
+++ b/ftw/upgrade/tests/test_command_sites.py
@@ -14,12 +14,12 @@ class TestSitesCommand(CommandAndInstanceTestCase):
 
     def test_listing_sites_as_table(self):
         exitcode, output = self.upgrade_script('sites')
-        self.assertEquals(0, exitcode)
-        self.assertEquals('/plone               Plone site\n', output)
+        self.assertEqual(0, exitcode)
+        self.assertEqual('/plone               Plone site\n', output)
 
     def test_listing_sites_as_json(self):
         exitcode, output = self.upgrade_script('sites --json')
-        self.assertEquals(0, exitcode)
+        self.assertEqual(0, exitcode)
         self.assert_json_equal([{'id': 'plone',
                                  'path': '/plone',
                                  'title': 'Plone site'}],
@@ -28,7 +28,7 @@ class TestSitesCommand(CommandAndInstanceTestCase):
     def test_error_when_no_site_reachable(self):
         self.layer['root_path'].joinpath('parts/instance').rmtree()
         exitcode, output = self.upgrade_script('sites', assert_exitcode=False)
-        self.assertEquals(1, exitcode)
+        self.assertEqual(1, exitcode)
         self.assertMultiLineEqual(
             'ERROR: No running Plone instance detected.\n',
             output)

--- a/ftw/upgrade/tests/test_command_touch.py
+++ b/ftw/upgrade/tests/test_command_touch.py
@@ -1,7 +1,7 @@
-from ftw.upgrade.tests.base import CommandTestCase
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.upgrade.tests.base import CommandTestCase
 
 
 class TestTouchCommand(CommandTestCase):

--- a/ftw/upgrade/tests/test_command_touch.py
+++ b/ftw/upgrade/tests/test_command_touch.py
@@ -3,6 +3,8 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.upgrade.tests.base import CommandTestCase
 
+import six
+
 
 class TestTouchCommand(CommandTestCase):
 
@@ -29,8 +31,9 @@ class TestTouchCommand(CommandTestCase):
                          'Expected path to no longer exist: {0}'.format(path))
 
         new_step_path, = path.dirname().dirs()
-        self.assertRegexpMatches(new_step_path.name,
-                                 r'^{0}\d{{10}}_add_action'.format(datetime.now().year))
+        six.assertRegex(
+            self, new_step_path.name,
+            r'^{0}\d{{10}}_add_action'.format(datetime.now().year))
 
     def test_moving_after_another(self):
         self.package = create(

--- a/ftw/upgrade/tests/test_command_user.py
+++ b/ftw/upgrade/tests/test_command_user.py
@@ -1,6 +1,7 @@
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
+
 import os
 
 

--- a/ftw/upgrade/tests/test_command_user.py
+++ b/ftw/upgrade/tests/test_command_user.py
@@ -16,24 +16,24 @@ class TestUserCommand(CommandAndInstanceTestCase):
 
     def test_prints_authenticated_user(self):
         exitcode, output = self.upgrade_script('user')
-        self.assertEquals(0, exitcode)
-        self.assertEquals('Authenticated as "admin".\n', output)
+        self.assertEqual(0, exitcode)
+        self.assertEqual('Authenticated as "admin".\n', output)
 
     def test_authentication_by_param(self):
         del os.environ['UPGRADE_AUTHENTICATION']
         exitcode, output = self.upgrade_script('user --auth {0}:{1}'.format(
                 SITE_OWNER_NAME, TEST_USER_PASSWORD))
-        self.assertEquals(0, exitcode)
-        self.assertEquals('Authenticated as "admin".\n', output)
+        self.assertEqual(0, exitcode)
+        self.assertEqual('Authenticated as "admin".\n', output)
 
     def test_tempfile_authentication_fallback(self):
         del os.environ['UPGRADE_AUTHENTICATION']
         exitcode, output = self.upgrade_script('user')
-        self.assertEquals(0, exitcode)
-        self.assertEquals('Authenticated as "system-upgrade".\n', output)
+        self.assertEqual(0, exitcode)
+        self.assertEqual('Authenticated as "system-upgrade".\n', output)
 
     def test_valid_authentication_format_is_required(self):
         exitcode, output = self.upgrade_script('user --auth=john', assert_exitcode=False)
-        self.assertEquals(1, exitcode)
-        self.assertEquals('ERROR: Invalid authentication information "john".',
-                          output.splitlines()[0])
+        self.assertEqual(1, exitcode)
+        self.assertEqual('ERROR: Invalid authentication information "john".',
+                         output.splitlines()[0])

--- a/ftw/upgrade/tests/test_command_utils.py
+++ b/ftw/upgrade/tests/test_command_utils.py
@@ -7,7 +7,7 @@ from ftw.upgrade.command.utils import find_package_namespace_path
 from ftw.upgrade.tests.helpers import capture_streams
 from ftw.upgrade.tests.helpers import chdir
 from path import Path
-from StringIO import StringIO
+from six import StringIO
 from unittest import TestCase
 
 

--- a/ftw/upgrade/tests/test_command_utils.py
+++ b/ftw/upgrade/tests/test_command_utils.py
@@ -40,8 +40,8 @@ class TestFindEgginfo(TestCase):
         with capture_streams(stderr=stderr):
             self.assertEqual(None, find_egginfo(self.path))
 
-        self.assertEquals('WARNING: no *.egg-info directory could be found.\n',
-                          stderr.getvalue())
+        self.assertEqual('WARNING: no *.egg-info directory could be found.\n',
+                         stderr.getvalue())
 
     def test_prints_warning_when_multiple_egginfos_found(self):
         create(self.package_builder)
@@ -51,8 +51,8 @@ class TestFindEgginfo(TestCase):
         with capture_streams(stderr=stderr):
             self.assertEqual(None, find_egginfo(self.path))
 
-        self.assertEquals('WARNING: more than one *.egg-info directory found.\n',
-                          stderr.getvalue())
+        self.assertEqual('WARNING: more than one *.egg-info directory found.\n',
+                         stderr.getvalue())
 
 
 class TestFindPackageNamespacePath(TestCase):
@@ -64,5 +64,5 @@ class TestFindPackageNamespacePath(TestCase):
     def test_returns_absolute_path_to_toplevel_namespace_directory(self):
         create(Builder('python package').named('the.package').at_path(self.path))
         egginfo = find_egginfo(self.path)
-        self.assertEquals(self.path.joinpath('the'),
-                          find_package_namespace_path(egginfo))
+        self.assertEqual(self.path.joinpath('the'),
+                         find_package_namespace_path(egginfo))

--- a/ftw/upgrade/tests/test_directory_meta_directive.py
+++ b/ftw/upgrade/tests/test_directory_meta_directive.py
@@ -260,8 +260,11 @@ class TestDirectoryMetaDirective(UpgradeTestCase):
                  u'the.package:baz',
                  u'the.package:bar',
                  u'the.package:foo'],
-                filter(lambda profile_id: profile_id.startswith('the.package:'),
-                       get_sorted_profile_ids(portal_setup)))
+                [
+                    profile_id for profile_id
+                    in get_sorted_profile_ids(portal_setup)
+                    if profile_id.startswith('the.package:')
+                ])
 
     def test_handler_step_provides_interfaces_implemented_by_upgrade_step_class(self):
         code = '\n'.join((

--- a/ftw/upgrade/tests/test_directory_meta_directive.py
+++ b/ftw/upgrade/tests/test_directory_meta_directive.py
@@ -109,7 +109,7 @@ class TestDirectoryMetaDirective(UpgradeTestCase):
 
         with create(package_builder).zcml_loaded(self.layer['configurationContext']):
             import other.package
-            self.assertEquals('package root', other.package.PACKAGE)
+            self.assertEqual('package root', other.package.PACKAGE)
 
     def test_profile_must_be_registed_before_registering_upgrade_directory(self):
         package_builder = (Builder('python package')
@@ -254,7 +254,7 @@ class TestDirectoryMetaDirective(UpgradeTestCase):
                  'for': None})
 
             portal_setup = getToolByName(self.portal, 'portal_setup')
-            self.assertEquals(
+            self.assertEqual(
                 [u'the.package:default',
                  u'the.package:baz',
                  u'the.package:bar',
@@ -282,7 +282,7 @@ class TestDirectoryMetaDirective(UpgradeTestCase):
         with self.package_created():
             portal_setup = getToolByName(self.portal, 'portal_setup')
             steps = listUpgradeSteps(portal_setup, 'the.package:default', '10000000000000')
-            self.assertEquals(1, len(steps))
+            self.assertEqual(1, len(steps))
             six.assertCountEqual(
                 self,
                 (IRecordableHandler,

--- a/ftw/upgrade/tests/test_directory_scaffold.py
+++ b/ftw/upgrade/tests/test_directory_scaffold.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from ftw.testing import freeze
 from ftw.upgrade.directory.scaffold import UpgradeStepCreator
 from unittest import TestCase
+
 import os.path
 import re
 import shutil

--- a/ftw/upgrade/tests/test_directory_scanner.py
+++ b/ftw/upgrade/tests/test_directory_scanner.py
@@ -5,6 +5,7 @@ from ftw.builder import create
 from ftw.upgrade.directory.scanner import Scanner
 from ftw.upgrade.exceptions import UpgradeStepDefinitionError
 from ftw.upgrade.tests.base import UpgradeTestCase
+from six.moves import map
 
 
 class TestDirectoryScanner(UpgradeTestCase):
@@ -26,9 +27,9 @@ class TestDirectoryScanner(UpgradeTestCase):
                                   .named('remove the action'))
 
         with self.scanned() as upgrade_infos:
-            map(lambda info: (info.__delitem__('path'),
-                              info.__delitem__('callable')),
-                upgrade_infos)
+            list(map(lambda info: (info.__delitem__('path'),
+                                   info.__delitem__('callable')),
+                     upgrade_infos))
 
             self.maxDiff = None
             self.assertEqual(

--- a/ftw/upgrade/tests/test_directory_upgrade_steps.py
+++ b/ftw/upgrade/tests/test_directory_upgrade_steps.py
@@ -162,9 +162,9 @@ class TestDirectoryUpgradeSteps(UpgradeTestCase):
 
         with self.package_created():
             self.install_profile('the.package:default')
-            self.assertEquals({}, self.portal.upgrade_infos)
+            self.assertEqual({}, self.portal.upgrade_infos)
             self.install_profile_upgrades('the.package:default')
-            self.assertEquals(
+            self.assertEqual(
                 {'base_profile': u'profile-the.package:default',
                  'target_version': '20110101000000'},
                 self.portal.upgrade_infos)

--- a/ftw/upgrade/tests/test_executioner.py
+++ b/ftw/upgrade/tests/test_executioner.py
@@ -10,6 +10,7 @@ from Products.CMFCore.utils import getToolByName
 from unittest import skipIf
 from zope.component import queryAdapter
 from zope.interface.verify import verifyClass
+from Products.CMFPlone.utils import getFSVersionTuple
 
 import transaction
 
@@ -115,6 +116,7 @@ class TestExecutioner(UpgradeTestCase):
             with self.assert_resources_recooked():
                 self.install_profile_upgrades('the.package:default')
 
+    @skipIf(getFSVersionTuple() > (5, 1), 'QuickInstaller has been deprecated in Plone 5.1')
     def test_updates_quickinstaller_version(self):
         quickinstaller = getToolByName(self.portal, 'portal_quickinstaller')
 

--- a/ftw/upgrade/tests/test_executioner.py
+++ b/ftw/upgrade/tests/test_executioner.py
@@ -10,6 +10,7 @@ from Products.CMFCore.utils import getToolByName
 from unittest import skipIf
 from zope.component import queryAdapter
 from zope.interface.verify import verifyClass
+
 import transaction
 
 
@@ -96,7 +97,7 @@ class TestExecutioner(UpgradeTestCase):
 
             self.assertIn(
                 'notification_hook',
-                [f.func_name for f in hook_funcs],
+                [f.__name__ for f in hook_funcs],
                 'Our notification_hook should be registered')
 
             transaction.commit()

--- a/ftw/upgrade/tests/test_executioner.py
+++ b/ftw/upgrade/tests/test_executioner.py
@@ -102,7 +102,7 @@ class TestExecutioner(UpgradeTestCase):
                 'Our notification_hook should be registered')
 
             transaction.commit()
-            self.assertEquals(
+            self.assertEqual(
                 [],
                 list(transaction.get().getAfterCommitHooks()),
                 'Hook registrations should not persist across transactions')
@@ -128,9 +128,9 @@ class TestExecutioner(UpgradeTestCase):
         with self.package_created():
             self.install_profile('the.package:default', version='1000')
             quickinstaller.get('the.package').installedversion = '1.0'
-            self.assertEquals('1.0', quickinstaller.get('the.package').getInstalledVersion())
+            self.assertEqual('1.0', quickinstaller.get('the.package').getInstalledVersion())
             self.install_profile_upgrades('the.package:default')
-            self.assertEquals('1.1', quickinstaller.get('the.package').getInstalledVersion())
+            self.assertEqual('1.1', quickinstaller.get('the.package').getInstalledVersion())
 
     def test_install_profiles_by_profile_ids(self):
         self.package.with_profile(Builder('genericsetup profile')
@@ -142,21 +142,21 @@ class TestExecutioner(UpgradeTestCase):
         with self.package_created():
             executioner = queryAdapter(self.portal_setup, IExecutioner)
             executioner.install_profiles_by_profile_ids(profile_id)
-            self.assertEquals(
+            self.assertEqual(
                 ['Installing profile the.package:default.',
                  'Done installing profile the.package:default.'],
                 self.get_log())
 
             self.purge_log()
             executioner.install_profiles_by_profile_ids(profile_id)
-            self.assertEquals(
+            self.assertEqual(
                 ['Ignoring already installed profile the.package:default.'],
                 self.get_log())
 
             self.purge_log()
             executioner.install_profiles_by_profile_ids(profile_id,
                                                         force_reinstall=True)
-            self.assertEquals(
+            self.assertEqual(
                 ['Installing profile the.package:default.',
                  'Done installing profile the.package:default.'],
                 self.get_log())
@@ -178,14 +178,14 @@ class TestExecutioner(UpgradeTestCase):
                     'done': ['20121212121200'],
                     'proposed': ['20111111111100'],
                     'orphan': ['20111111111100']}})
-            self.assertEquals(
+            self.assertEqual(
                 (u'20121212121200',),
                 self.portal_setup.getLastVersionForProfile('the.package:default'))
 
             executioner = queryAdapter(self.portal_setup, IExecutioner)
             executioner.install_upgrades_by_api_ids(
                 '20111111111100@the.package:default')
-            self.assertEquals(
+            self.assertEqual(
                 (u'20121212121200',),
                 self.portal_setup.getLastVersionForProfile('the.package:default'))
             self.assert_gathered_upgrades({
@@ -218,7 +218,7 @@ class TestExecutioner(UpgradeTestCase):
             self.setup_logging()
 
             self.install_profile_upgrades('the.package:default')
-            self.assertEquals(
+            self.assertEqual(
                 '1 of 2 (50%): Processing indexing queue',
                 self.get_log()[-1])
 
@@ -242,14 +242,14 @@ class TestExecutioner(UpgradeTestCase):
                     'done': ['4002'],
                     'proposed': ['20111111111100'],
                     'orphan': []}})
-            self.assertEquals(
+            self.assertEqual(
                 (u'4002',),
                 self.portal_setup.getLastVersionForProfile('the.package:default'))
 
             executioner = queryAdapter(self.portal_setup, IExecutioner)
             executioner.install_upgrades_by_api_ids(
                 '20111111111100@the.package:default')
-            self.assertEquals(
+            self.assertEqual(
                 (u'20111111111100',),
                 self.portal_setup.getLastVersionForProfile('the.package:default'))
             self.assert_gathered_upgrades({

--- a/ftw/upgrade/tests/test_gatherer.py
+++ b/ftw/upgrade/tests/test_gatherer.py
@@ -159,7 +159,7 @@ class TestUpgradeInformationGatherer(UpgradeTestCase):
             self.install_profile('the.package:three')
             self.install_profile('the.package:four')
 
-            self.assertEquals(
+            self.assertEqual(
                 ['the.package:four',
                  'the.package:two',
                  'the.package:one'],
@@ -198,14 +198,14 @@ class TestUpgradeInformationGatherer(UpgradeTestCase):
 
         with self.package_created():
             self.install_profile('the.package:default')
-            self.assertEquals(['the.package:removed', 'the.package:default'],
-                              self.get_listed_profiles())
+            self.assertEqual(['the.package:removed', 'the.package:default'],
+                             self.get_listed_profiles())
 
             from Products.GenericSetup import profile_registry
             profile_registry.unregisterProfile('removed', 'the.package')
 
-            self.assertEquals(['the.package:default'],
-                              self.get_listed_profiles())
+            self.assertEqual(['the.package:default'],
+                             self.get_listed_profiles())
 
     def test_not_installable_products_are_not_checked_if_uninstalled(self):
         # Some profiles are not associated with a product.
@@ -461,7 +461,7 @@ class TestUpgradeInformationGatherer(UpgradeTestCase):
             self.install_profile('the.package:default')
 
             gatherer = queryAdapter(self.portal_setup, IUpgradeInformationGatherer)
-            self.assertEquals(
+            self.assertEqual(
                 gatherer.get_upgrades_by_api_ids('20110101000000@the.package:default',
                                                  '20120202000000@the.package:default'),
                 gatherer.get_upgrades_by_api_ids('20120202000000@the.package:default',
@@ -471,9 +471,9 @@ class TestUpgradeInformationGatherer(UpgradeTestCase):
         gatherer = queryAdapter(self.portal_setup, IUpgradeInformationGatherer)
         with self.assertRaises(UpgradeNotFound) as cm:
             gatherer.get_upgrades_by_api_ids('foo@bar:default')
-        self.assertEquals('foo@bar:default', cm.exception.api_id)
-        self.assertEquals('The upgrade "foo@bar:default" could not be found.',
-                          str(cm.exception))
+        self.assertEqual('foo@bar:default', cm.exception.api_id)
+        self.assertEqual('The upgrade "foo@bar:default" could not be found.',
+                         str(cm.exception))
 
     def get_listed_profiles(self, filter_package='the.package'):
         gatherer = queryAdapter(self.portal_setup, IUpgradeInformationGatherer)
@@ -496,8 +496,8 @@ class TestUpgradeInformationGatherer(UpgradeTestCase):
         result = gatherer.get_profiles()
         got_profiles = [profile['id'] for profile in result
                         if profile['outdated_fs_version'] and profile['id'] not in ignore]
-        self.assertEquals(expected_profiles, got_profiles,
-                          'Unexpected outdated fs versions for profiles.')
+        self.assertEqual(expected_profiles, got_profiles,
+                         'Unexpected outdated fs versions for profiles.')
 
 
 class TestExtendAutoUpgradesWithHumanFormattedDateVersion(TestCase):

--- a/ftw/upgrade/tests/test_gatherer.py
+++ b/ftw/upgrade/tests/test_gatherer.py
@@ -472,8 +472,10 @@ class TestUpgradeInformationGatherer(UpgradeTestCase):
         result = gatherer.get_profiles()
         profiles = [profile['id'] for profile in result]
         if filter_package:
-            profiles = filter(lambda profile: profile.startswith(filter_package),
-                              profiles)
+            profiles = [
+                profile for profile in profiles
+                if profile.startswith(filter_package)
+            ]
         return profiles
 
     def get_profiles_by_ids(self, **kwargs):

--- a/ftw/upgrade/tests/test_gatherer.py
+++ b/ftw/upgrade/tests/test_gatherer.py
@@ -10,6 +10,7 @@ from ftw.upgrade.tests.base import UpgradeTestCase
 from Products.CMFPlone.utils import getFSVersionTuple
 from unittest import TestCase
 from zope.component import queryAdapter
+from zope.component import getMultiAdapter
 from zope.interface.verify import verifyClass
 
 
@@ -107,6 +108,8 @@ class TestUpgradeInformationGatherer(UpgradeTestCase):
         self.package.with_profile(Builder('genericsetup profile')
                                   .with_upgrade(Builder('plone upgrade step')
                                                 .upgrading('1', to='2')))
+        self.package.with_profile(Builder('genericsetup profile')
+                                  .named('uninstall'))
 
         with self.package_created():
             self.assertNotIn('the.package:default', self.get_listed_profiles(),
@@ -116,7 +119,12 @@ class TestUpgradeInformationGatherer(UpgradeTestCase):
             self.assertIn('the.package:default', self.get_listed_profiles(),
                           'Installed profiles should be listed.')
 
-            self.portal_quickinstaller.uninstallProducts(['the.package'])
+            if getFSVersionTuple() > (5, 1):
+                installer = getMultiAdapter(
+                    (self.portal, self.layer['request']), name='installer')
+                installer.uninstall_product('the.package')
+            else:
+                self.portal_quickinstaller.uninstallProducts(['the.package'])
             self.assertNotIn('the.package:default', self.get_listed_profiles(),
                              'Packages uninstalled by quickinstaller should not be listed.')
 

--- a/ftw/upgrade/tests/test_helpers.py
+++ b/ftw/upgrade/tests/test_helpers.py
@@ -42,21 +42,21 @@ class TestUpdateSecurity(WorkflowTestCase):
         folder = create(Builder('folder')
                         .in_state('published'))
 
-        self.assertEquals(['Anonymous'],
-                          self.get_allowed_roles_and_users(folder))
+        self.assertEqual(['Anonymous'],
+                         self.get_allowed_roles_and_users(folder))
         folder.reindexObjectSecurity()
 
         folder.manage_permission(
             ALLOWED_ROLES_AND_USERS_PERMISSION, roles=['Reader'], acquire=False)
         folder.reindexObjectSecurity()
 
-        self.assertEquals(['Reader'],
-                          self.get_allowed_roles_and_users(folder))
+        self.assertEqual(['Reader'],
+                         self.get_allowed_roles_and_users(folder))
 
         update_security_for(folder)
 
-        self.assertEquals(['Anonymous'],
-                          self.get_allowed_roles_and_users(folder))
+        self.assertEqual(['Anonymous'],
+                         self.get_allowed_roles_and_users(folder))
 
     def test_without_reindexing_security(self):
         self.set_workflow_chain(for_type='Folder',
@@ -64,17 +64,17 @@ class TestUpdateSecurity(WorkflowTestCase):
         folder = create(Builder('folder')
                         .in_state('published'))
 
-        self.assertEquals(['Anonymous'],
-                          self.get_allowed_roles_and_users(folder))
+        self.assertEqual(['Anonymous'],
+                         self.get_allowed_roles_and_users(folder))
 
         folder.manage_permission(
             ALLOWED_ROLES_AND_USERS_PERMISSION, roles=['Reader'], acquire=False)
         folder.reindexObjectSecurity()
 
-        self.assertEquals(['Reader'],
-                          self.get_allowed_roles_and_users(folder))
+        self.assertEqual(['Reader'],
+                         self.get_allowed_roles_and_users(folder))
 
         update_security_for(folder, reindex_security=False)
 
-        self.assertEquals(['Reader'],
-                          self.get_allowed_roles_and_users(folder))
+        self.assertEqual(['Reader'],
+                         self.get_allowed_roles_and_users(folder))

--- a/ftw/upgrade/tests/test_helpers.py
+++ b/ftw/upgrade/tests/test_helpers.py
@@ -2,6 +2,12 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.upgrade.helpers import update_security_for
 from ftw.upgrade.tests.base import WorkflowTestCase
+from Products.CMFPlone.utils import getFSVersionTuple
+
+
+ALLOWED_ROLES_AND_USERS_PERMISSION = 'View'
+if getFSVersionTuple() > (5, 2):
+    ALLOWED_ROLES_AND_USERS_PERMISSION = 'Access contents information'
 
 
 class TestUpdateSecurity(WorkflowTestCase):
@@ -40,7 +46,8 @@ class TestUpdateSecurity(WorkflowTestCase):
                           self.get_allowed_roles_and_users(folder))
         folder.reindexObjectSecurity()
 
-        folder.manage_permission('View', roles=['Reader'], acquire=False)
+        folder.manage_permission(
+            ALLOWED_ROLES_AND_USERS_PERMISSION, roles=['Reader'], acquire=False)
         folder.reindexObjectSecurity()
 
         self.assertEquals(['Reader'],
@@ -60,7 +67,8 @@ class TestUpdateSecurity(WorkflowTestCase):
         self.assertEquals(['Anonymous'],
                           self.get_allowed_roles_and_users(folder))
 
-        folder.manage_permission('View', roles=['Reader'], acquire=False)
+        folder.manage_permission(
+            ALLOWED_ROLES_AND_USERS_PERMISSION, roles=['Reader'], acquire=False)
         folder.reindexObjectSecurity()
 
         self.assertEquals(['Reader'],

--- a/ftw/upgrade/tests/test_jsonapi_plonesite.py
+++ b/ftw/upgrade/tests/test_jsonapi_plonesite.py
@@ -140,7 +140,7 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
                                    message='Method Not Allowed',
                                    details='Action requires GET'):
             self.api_request('POST', 'get_profile', {'profileid': 'the.package:default'})
-        self.assertEquals('GET', browser.headers.get('allow'))
+        self.assertEqual('GET', browser.headers.get('allow'))
 
     @browsing
     def test_get_unkown_profile_returns_error(self, browser):
@@ -369,7 +369,7 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
                                    message='Method Not Allowed',
                                    details='Action requires POST'):
             self.api_request('GET', 'execute_upgrades', {'upgrades:list': 'foo@bar:default'})
-        self.assertEquals('POST', browser.headers.get('allow'))
+        self.assertEqual('POST', browser.headers.get('allow'))
 
     @browsing
     def test_execute_upgrades_not_allowed_when_plone_outdated(self, browser):
@@ -563,9 +563,9 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
     @browsing
     def test_plone_upgrade_needed(self, browser):
         self.api_request('GET', 'plone_upgrade_needed')
-        self.assertEquals(False, browser.json)
+        self.assertEqual(False, browser.json)
 
         self.portal_setup.setLastVersionForProfile(_DEFAULT_PROFILE, '4')
         transaction.commit()
         self.api_request('GET', 'plone_upgrade_needed')
-        self.assertEquals(True, browser.json)
+        self.assertEqual(True, browser.json)

--- a/ftw/upgrade/tests/test_jsonapi_plonesite.py
+++ b/ftw/upgrade/tests/test_jsonapi_plonesite.py
@@ -563,9 +563,9 @@ class TestPloneSiteJsonApi(JsonApiTestCase):
     @browsing
     def test_plone_upgrade_needed(self, browser):
         self.api_request('GET', 'plone_upgrade_needed')
-        self.assertEquals('false', browser.contents.strip())
+        self.assertEquals(False, browser.json)
 
         self.portal_setup.setLastVersionForProfile(_DEFAULT_PROFILE, '4')
         transaction.commit()
         self.api_request('GET', 'plone_upgrade_needed')
-        self.assertEquals('true', browser.contents.strip())
+        self.assertEquals(True, browser.json)

--- a/ftw/upgrade/tests/test_jsonapi_plonesite.py
+++ b/ftw/upgrade/tests/test_jsonapi_plonesite.py
@@ -4,6 +4,7 @@ from ftw.testbrowser import browsing
 from ftw.upgrade.tests.base import JsonApiTestCase
 from ftw.upgrade.utils import get_portal_migration
 from Products.CMFPlone.factory import _DEFAULT_PROFILE
+
 import re
 import transaction
 

--- a/ftw/upgrade/tests/test_jsonapi_zopeapp.py
+++ b/ftw/upgrade/tests/test_jsonapi_zopeapp.py
@@ -27,7 +27,7 @@ class TestZopeAppJsonApi(JsonApiTestCase):
 
             browser.json)
 
-        self.assertTrue(browser.contents.endswith('\n'),
+        self.assertTrue(browser.body.endswith(b'\n'),
                         'There should always be a trailing newline.')
 
     @browsing
@@ -43,7 +43,7 @@ class TestZopeAppJsonApi(JsonApiTestCase):
     @browsing
     def test_current_user(self, browser):
         self.api_request('GET', 'current_user', context=self.app)
-        self.assertEqual('"admin"\n', browser.contents)
+        self.assertEqual('admin', browser.json)
 
     @browsing
     def test_requiring_available_api_version_by_url(self, browser):
@@ -61,7 +61,7 @@ class TestZopeAppJsonApi(JsonApiTestCase):
                                    details='The API version "v100" is not available.'):
             self.api_request('GET', 'v100/list_plone_sites', context=self.app)
 
-        self.assertTrue(browser.contents.endswith('\n'),
+        self.assertTrue(browser.body.endswith(b'\n'),
                         'There should always be a trailing newline.')
 
     @browsing

--- a/ftw/upgrade/tests/test_manage_view.py
+++ b/ftw/upgrade/tests/test_manage_view.py
@@ -8,6 +8,7 @@ from plone.app.testing import SITE_OWNER_NAME
 from Products.CMFCore.utils import getToolByName
 from StringIO import StringIO
 from unittest import TestCase
+
 import logging
 import re
 import transaction

--- a/ftw/upgrade/tests/test_manage_view.py
+++ b/ftw/upgrade/tests/test_manage_view.py
@@ -49,9 +49,9 @@ class TestResponseLogger(TestCase):
         response.seek(0)
         output = response.read().strip()
         # Dynamically replace paths so that it works on all machines
-        output = re.sub(rb'(File ").*(ftw/upgrade/.*")',
-                        rb'\1/.../\2', output)
-        output = re.sub(rb'(line )\d*', rb'line XX', output)
+        output = re.sub(br'(File ").*(ftw/upgrade/.*")',
+                        br'\1/.../\2', output)
+        output = re.sub(br'(line )\d*', br'line XX', output)
 
         self.assertEqual(
             [b'FAILED',
@@ -84,9 +84,9 @@ class TestResponseLogger(TestCase):
         response.seek(0)
         output = response.read().strip()
         # Dynamically replace paths so that it works on all machines
-        output = re.sub(rb'(File ").*(ftw/upgrade/.*")',
-                        rb'\1/.../\2', output)
-        output = re.sub(rb'(line )\d*', rb'line XX', output)
+        output = re.sub(br'(File ").*(ftw/upgrade/.*")',
+                        br'\1/.../\2', output)
+        output = re.sub(br'(line )\d*', br'line XX', output)
 
         self.assertEqual(
             [b'FAILED',

--- a/ftw/upgrade/tests/test_manage_view.py
+++ b/ftw/upgrade/tests/test_manage_view.py
@@ -6,7 +6,7 @@ from ftw.upgrade.browser.manage import ResponseLogger
 from ftw.upgrade.tests.base import UpgradeTestCase
 from plone.app.testing import SITE_OWNER_NAME
 from Products.CMFCore.utils import getToolByName
-from StringIO import StringIO
+from six import BytesIO
 from unittest import TestCase
 
 import logging
@@ -17,7 +17,7 @@ import transaction
 class TestResponseLogger(TestCase):
 
     def test_logging(self):
-        response = StringIO()
+        response = BytesIO()
 
         with ResponseLogger(response):
             logging.error('foo')
@@ -25,22 +25,22 @@ class TestResponseLogger(TestCase):
 
         response.seek(0)
         self.assertEqual(
-            ['foo', u'bar'],
-            response.read().strip().split('\n'))
+            [b'foo', b'bar'],
+            response.read().strip().split(b'\n'))
 
     def test_logged_tags_get_escaped(self):
-        response = StringIO()
+        response = BytesIO()
 
         with ResponseLogger(response):
             logging.error('ERROR: Something at <TextBlock at /bla/blub>')
 
         response.seek(0)
         self.assertEqual(
-            ['ERROR: Something at &lt;TextBlock at /bla/blub&gt;'],
-            response.read().strip().split('\n'))
+            [b'ERROR: Something at &lt;TextBlock at /bla/blub&gt;'],
+            response.read().strip().split(b'\n'))
 
     def test_logging_exceptions(self):
-        response = StringIO()
+        response = BytesIO()
 
         with self.assertRaises(KeyError):
             with ResponseLogger(response):
@@ -49,21 +49,21 @@ class TestResponseLogger(TestCase):
         response.seek(0)
         output = response.read().strip()
         # Dynamically replace paths so that it works on all machines
-        output = re.sub(r'(File ").*(ftw/upgrade/.*")',
-                        r'\1/.../\2', output)
-        output = re.sub(r'(line )\d*', r'line XX', output)
+        output = re.sub(rb'(File ").*(ftw/upgrade/.*")',
+                        rb'\1/.../\2', output)
+        output = re.sub(rb'(line )\d*', rb'line XX', output)
 
         self.assertEqual(
-            ['FAILED',
-             'Traceback (most recent call last):',
-             '  File "/.../ftw/upgrade/tests/'
-             'test_manage_view.py", line XX, in test_logging_exceptions',
-             "    raise KeyError('foo')",
-             "KeyError: 'foo'"],
-            output.split('\n'))
+            [b'FAILED',
+             b'Traceback (most recent call last):',
+             b'  File "/.../ftw/upgrade/tests/'
+             b'test_manage_view.py", line XX, in test_logging_exceptions',
+             b"    raise KeyError('foo')",
+             b"KeyError: 'foo'"],
+            output.split(b'\n'))
 
     def test_annotate_result_on_success(self):
-        response = StringIO()
+        response = BytesIO()
 
         with ResponseLogger(response, annotate_result=True):
             logging.error('foo')
@@ -71,11 +71,11 @@ class TestResponseLogger(TestCase):
 
         response.seek(0)
         self.assertEqual(
-            ['foo', u'bar', 'Result: SUCCESS'],
-            response.read().strip().split('\n'))
+            [b'foo', b'bar', b'Result: SUCCESS'],
+            response.read().strip().split(b'\n'))
 
     def test_annotate_result_on_error(self):
-        response = StringIO()
+        response = BytesIO()
 
         with self.assertRaises(KeyError):
             with ResponseLogger(response, annotate_result=True):
@@ -84,19 +84,19 @@ class TestResponseLogger(TestCase):
         response.seek(0)
         output = response.read().strip()
         # Dynamically replace paths so that it works on all machines
-        output = re.sub(r'(File ").*(ftw/upgrade/.*")',
-                        r'\1/.../\2', output)
-        output = re.sub(r'(line )\d*', r'line XX', output)
+        output = re.sub(rb'(File ").*(ftw/upgrade/.*")',
+                        rb'\1/.../\2', output)
+        output = re.sub(rb'(line )\d*', rb'line XX', output)
 
         self.assertEqual(
-            ['FAILED',
-             'Traceback (most recent call last):',
-             '  File "/.../ftw/upgrade/tests/'
-             'test_manage_view.py", line XX, in test_annotate_result_on_error',
-             "    raise KeyError('foo')",
-             "KeyError: 'foo'",
-             'Result: FAILURE'],
-            output.split('\n'))
+            [b'FAILED',
+             b'Traceback (most recent call last):',
+             b'  File "/.../ftw/upgrade/tests/'
+             b'test_manage_view.py", line XX, in test_annotate_result_on_error',
+             b"    raise KeyError('foo')",
+             b"KeyError: 'foo'",
+             b'Result: FAILURE'],
+            output.split(b'\n'))
 
 
 class TestManageUpgrades(UpgradeTestCase):

--- a/ftw/upgrade/tests/test_manage_view.py
+++ b/ftw/upgrade/tests/test_manage_view.py
@@ -106,19 +106,25 @@ class TestManageUpgrades(UpgradeTestCase):
         self.portal_url = self.layer['portal'].portal_url()
         self.portal = self.layer['portal']
 
+    def assertEqualURL(self, first, second, msg=None):
+        # WebOb generates requests that always contain the port even for the
+        # default port 80.
+        return self.assertEqual(
+            first.replace(':80', ''), second.replace(':80', ''), msg)
+
     @browsing
     def test_registered_in_controlpanel(self, browser):
         browser.login(SITE_OWNER_NAME).open(view='overview-controlpanel')
         link = browser.css('#content').find('Upgrades').first
-        self.assertEqual(self.portal_url + '/@@manage-upgrades', link.attrib['href'])
+        self.assertEqualURL(self.portal_url + '/@@manage-upgrades', link.attrib['href'])
 
     @browsing
     def test_manage_view_renders(self, browser):
         browser.login(SITE_OWNER_NAME).open(view='manage-upgrades')
 
         up_link = browser.css('#content').find('Up to Site Setup').first
-        self.assertEqual(self.portal_url + '/@@overview-controlpanel',
-                         up_link.attrib['href'])
+        self.assertEqualURL(self.portal_url + '/@@overview-controlpanel',
+                            up_link.attrib['href'])
 
         self.assertTrue(browser.css('input[value="plone.app.discussion:default"]').first)
 

--- a/ftw/upgrade/tests/test_migration.py
+++ b/ftw/upgrade/tests/test_migration.py
@@ -7,6 +7,7 @@ from ftw.testing import freeze
 from ftw.upgrade.migration import BACKUP_AND_IGNORE_UNMAPPED_FIELDS
 from ftw.upgrade.migration import DISABLE_FIELD_AUTOMAPPING
 from ftw.upgrade.migration import FieldsNotMappedError
+from ftw.upgrade.migration import IBaseObject
 from ftw.upgrade.migration import IGNORE_DEFAULT_IGNORE_FIELDS
 from ftw.upgrade.migration import IGNORE_STANDARD_FIELD_MAPPING
 from ftw.upgrade.migration import IGNORE_UNMAPPED_FIELDS
@@ -21,7 +22,6 @@ from plone.app.textfield import RichTextValue
 from plone.dexterity.interfaces import IDexterityContent
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
-from Products.Archetypes.interfaces import IBaseObject
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.constrains import ENABLED
 from Products.CMFPlone.interfaces.constrains import IConstrainTypes

--- a/ftw/upgrade/tests/test_migration.py
+++ b/ftw/upgrade/tests/test_migration.py
@@ -265,7 +265,7 @@ class TestInplaceMigrator(UpgradeTestCase):
         InplaceMigrator('Folder', {'title': 'description'},
                         ignore_fields=['description']).migrate_object(folder)
         folder = self.portal.get(folder.getId())
-        self.assertEquals(u'The Title', folder.Description())
+        self.assertEqual(u'The Title', folder.Description())
 
     def test_DISABLE_FIELD_AUTOMAPPING_flag(self):
         """When disabling field automapping we expect unmaped fields.
@@ -304,7 +304,7 @@ class TestInplaceMigrator(UpgradeTestCase):
                 options=DISABLE_FIELD_AUTOMAPPING | BACKUP_AND_IGNORE_UNMAPPED_FIELDS)
             .migrate_object(folder))
 
-        self.assertEquals(
+        self.assertEqual(
             {'nextPreviousEnabled': False,
              'description': u'A very fancy folder.',
              'contributors': (),
@@ -380,8 +380,8 @@ class TestInplaceMigrator(UpgradeTestCase):
         folder.changeOwnership(peter.getUser())
 
         self.assertTrue(IBaseObject.providedBy(folder))
-        self.assertEquals('john.doe', folder.Creator())
-        self.assertEquals('peter.pan', folder.getOwner().getId())
+        self.assertEqual('john.doe', folder.Creator())
+        self.assertEqual('peter.pan', folder.getOwner().getId())
 
         self.grant('Manager')
         self.install_profile('plone.app.contenttypes:default')
@@ -390,8 +390,8 @@ class TestInplaceMigrator(UpgradeTestCase):
 
         folder = self.portal.get('the-folder')
         self.assertTrue(IDexterityContent.providedBy(folder))
-        self.assertEquals('john.doe', folder.Creator())
-        self.assertEquals('peter.pan', folder.getOwner().getId())
+        self.assertEqual('john.doe', folder.Creator())
+        self.assertEqual('peter.pan', folder.getOwner().getId())
 
     def test_migrate_ownership_no_IOwner(self):
         john = create(Builder('user').named('John', 'Doe').with_roles('Manager'))
@@ -402,8 +402,8 @@ class TestInplaceMigrator(UpgradeTestCase):
         folder.changeOwnership(peter.getUser())
 
         self.assertTrue(IBaseObject.providedBy(folder))
-        self.assertEquals('john.doe', folder.Creator())
-        self.assertEquals('peter.pan', folder.getOwner().getId())
+        self.assertEqual('john.doe', folder.Creator())
+        self.assertEqual('peter.pan', folder.getOwner().getId())
 
         self.grant('Manager')
         self.install_profile('plone.app.contenttypes:default')
@@ -419,8 +419,8 @@ class TestInplaceMigrator(UpgradeTestCase):
 
         folder = self.portal.get('the-folder')
         self.assertTrue(IDexterityContent.providedBy(folder))
-        self.assertEquals('john.doe', folder.Creator())
-        self.assertEquals('peter.pan', folder.getOwner().getId())
+        self.assertEqual('john.doe', folder.Creator())
+        self.assertEqual('peter.pan', folder.getOwner().getId())
 
     def test_migrate_object_position(self):
         self.grant('Manager')
@@ -429,11 +429,11 @@ class TestInplaceMigrator(UpgradeTestCase):
         two = create(Builder('folder').titled(u'Two').within(container))
         three = create(Builder('folder').titled(u'Three').within(container))
 
-        self.assertEquals(
+        self.assertEqual(
             [0, 1, 2],
             list(map(container.getObjectPosition, ('one', 'two', 'three'))))
         container.moveObjectsByDelta(['three'], -1)
-        self.assertEquals(
+        self.assertEqual(
             [0, 2, 1],
             list(map(container.getObjectPosition, ('one', 'two', 'three'))))
 
@@ -444,7 +444,7 @@ class TestInplaceMigrator(UpgradeTestCase):
         InplaceMigrator('Folder').migrate_object(one)
         container = self.portal.get('container')
 
-        self.assertEquals(
+        self.assertEqual(
             [0, 2, 1],
             list(map(container.getObjectPosition, ('one', 'two', 'three'))))
 
@@ -456,17 +456,17 @@ class TestInplaceMigrator(UpgradeTestCase):
                          .within(folder)
                          .in_manager('plone.rightcolumn'))
 
-        self.assertEquals({'plone.leftcolumn': [],
-                           'plone.rightcolumn': [portlet]},
-                          self.get_portlets_for(folder))
+        self.assertEqual({'plone.leftcolumn': [],
+                          'plone.rightcolumn': [portlet]},
+                         self.get_portlets_for(folder))
 
         self.install_profile('plone.app.contenttypes:default')
         InplaceMigrator('Folder').migrate_object(folder)
 
         folder = self.portal.get('the-folder')
-        self.assertEquals({'plone.leftcolumn': [],
-                           'plone.rightcolumn': [portlet]},
-                          self.get_portlets_for(folder))
+        self.assertEqual({'plone.leftcolumn': [],
+                          'plone.rightcolumn': [portlet]},
+                         self.get_portlets_for(folder))
 
     def test_migrate_relations(self):
         self.grant('Manager')
@@ -475,8 +475,8 @@ class TestInplaceMigrator(UpgradeTestCase):
         bar = create(Builder('folder').titled(u'Bar')
                      .having(relatedItems=[foo]))
 
-        self.assertEquals([foo], bar.getRelatedItems())
-        self.assertEquals([bar], foo.getBackReferences())
+        self.assertEqual([foo], bar.getRelatedItems())
+        self.assertEqual([bar], foo.getBackReferences())
 
         self.install_profile('plone.app.contenttypes:default')
         list(map(InplaceMigrator('Folder').migrate_object, (foo, bar)))
@@ -484,7 +484,7 @@ class TestInplaceMigrator(UpgradeTestCase):
         foo = self.portal.get('foo')
         bar = self.portal.get('bar')
 
-        self.assertEquals(
+        self.assertEqual(
             [foo],
             list(map(attrgetter('to_object'), IRelatedItems(bar).relatedItems)))
 
@@ -513,7 +513,7 @@ class TestInplaceMigrator(UpgradeTestCase):
                     ctypes.getImmediatelyAddableTypes())}
 
     def set_constraintypes_config(self, obj, config):
-        self.assertEquals(
+        self.assertEqual(
             {'mode', 'locally allowed', 'immediately addable'},
             set(config))
 

--- a/ftw/upgrade/tests/test_migration.py
+++ b/ftw/upgrade/tests/test_migration.py
@@ -27,6 +27,7 @@ from Products.CMFPlone.interfaces.constrains import ENABLED
 from Products.CMFPlone.interfaces.constrains import IConstrainTypes
 from Products.CMFPlone.interfaces.constrains import ISelectableConstrainTypes
 from Products.CMFPlone.utils import getFSVersionTuple
+from six.moves import map
 from unittest import skipIf
 from zope.annotation import IAnnotations
 from zope.component import getMultiAdapter
@@ -428,9 +429,13 @@ class TestInplaceMigrator(UpgradeTestCase):
         two = create(Builder('folder').titled(u'Two').within(container))
         three = create(Builder('folder').titled(u'Three').within(container))
 
-        self.assertEquals([0, 1, 2], map(container.getObjectPosition, ('one', 'two', 'three')))
+        self.assertEquals(
+            [0, 1, 2],
+            list(map(container.getObjectPosition, ('one', 'two', 'three'))))
         container.moveObjectsByDelta(['three'], -1)
-        self.assertEquals([0, 2, 1], map(container.getObjectPosition, ('one', 'two', 'three')))
+        self.assertEquals(
+            [0, 2, 1],
+            list(map(container.getObjectPosition, ('one', 'two', 'three'))))
 
         self.install_profile('plone.app.contenttypes:default')
         InplaceMigrator('Folder').migrate_object(container)
@@ -439,7 +444,9 @@ class TestInplaceMigrator(UpgradeTestCase):
         InplaceMigrator('Folder').migrate_object(one)
         container = self.portal.get('container')
 
-        self.assertEquals([0, 2, 1], map(container.getObjectPosition, ('one', 'two', 'three')))
+        self.assertEquals(
+            [0, 2, 1],
+            list(map(container.getObjectPosition, ('one', 'two', 'three'))))
 
     def test_migrate_portlets(self):
         self.grant('Manager')
@@ -472,14 +479,14 @@ class TestInplaceMigrator(UpgradeTestCase):
         self.assertEquals([bar], foo.getBackReferences())
 
         self.install_profile('plone.app.contenttypes:default')
-        map(InplaceMigrator('Folder').migrate_object, (foo, bar))
+        list(map(InplaceMigrator('Folder').migrate_object, (foo, bar)))
 
         foo = self.portal.get('foo')
         bar = self.portal.get('bar')
 
-        self.assertEquals([foo],
-                          map(attrgetter('to_object'),
-                              IRelatedItems(bar).relatedItems))
+        self.assertEquals(
+            [foo],
+            list(map(attrgetter('to_object'), IRelatedItems(bar).relatedItems)))
 
     def get_catalog_indexdata_for(self, obj):
         catalog = getToolByName(obj, 'portal_catalog')
@@ -529,6 +536,6 @@ class TestInplaceMigrator(UpgradeTestCase):
                 IPortletAssignmentMapping,
                 context=self.portal
             )
-            portlets[manager_name] = assignments.values()
+            portlets[manager_name] = list(assignments.values())
 
         return portlets

--- a/ftw/upgrade/tests/test_placefulworkflow.py
+++ b/ftw/upgrade/tests/test_placefulworkflow.py
@@ -86,6 +86,6 @@ class TestPlacefulWorkflowPolicyActivator(WorkflowTestCase):
                 ('intranet_workflow', 'plone_workflow'): {
                     'internal': 'published'}})
 
-        self.assertEquals(
+        self.assertEqual(
             ['Anonymous'],
             self.get_allowed_roles_and_users(for_object=container))

--- a/ftw/upgrade/tests/test_post_upgrade.py
+++ b/ftw/upgrade/tests/test_post_upgrade.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.upgrade.interfaces import IPostUpgrade
 from ftw.upgrade.tests.base import UpgradeTestCase
+from six.moves import map
 from zope.interface import Interface
 
 
@@ -61,8 +62,9 @@ class TestPostUpgrade(UpgradeTestCase):
                                              provided=IPostUpgrade,
                                              name=profile_id)
 
-            map(register_post_component_adapter,
-                ('the.package:addon', 'the.package:product', 'the.package:customization'))
+            list(map(register_post_component_adapter,
+                     ('the.package:addon', 'the.package:product',
+                      'the.package:customization')))
 
             self.assertEquals([], execution_order)
             self.install_profile_upgrades('the.package:customization')

--- a/ftw/upgrade/tests/test_post_upgrade.py
+++ b/ftw/upgrade/tests/test_post_upgrade.py
@@ -66,10 +66,10 @@ class TestPostUpgrade(UpgradeTestCase):
                      ('the.package:addon', 'the.package:product',
                       'the.package:customization')))
 
-            self.assertEquals([], execution_order)
+            self.assertEqual([], execution_order)
             self.install_profile_upgrades('the.package:customization')
 
-            self.assertEquals(['the.package:addon',
-                               'the.package:product',
-                               'the.package:customization'],
-                              execution_order)
+            self.assertEqual(['the.package:addon',
+                              'the.package:product',
+                              'the.package:customization'],
+                             execution_order)

--- a/ftw/upgrade/tests/test_progresslogger.py
+++ b/ftw/upgrade/tests/test_progresslogger.py
@@ -1,6 +1,6 @@
 from ftw.upgrade.progresslogger import ProgressLogger
+from six import StringIO
 from six.moves import range
-from StringIO import StringIO
 from time import sleep
 from unittest import TestCase
 

--- a/ftw/upgrade/tests/test_progresslogger.py
+++ b/ftw/upgrade/tests/test_progresslogger.py
@@ -94,7 +94,7 @@ class TestProgressLogger(TestCase):
                 if item == 4:
                     raise ValueError('baz')
 
-        self.assertEquals(['STARTING Foo',
-                           '1 of 5 (20%): Foo',
-                           'FAILED Foo (GeneratorExit: ) at 4'],
-                          self.read_log())
+        self.assertEqual(['STARTING Foo',
+                          '1 of 5 (20%): Foo',
+                          'FAILED Foo (GeneratorExit: ) at 4'],
+                         self.read_log())

--- a/ftw/upgrade/tests/test_progresslogger.py
+++ b/ftw/upgrade/tests/test_progresslogger.py
@@ -1,7 +1,9 @@
-from StringIO import StringIO
 from ftw.upgrade.progresslogger import ProgressLogger
+from six.moves import range
+from StringIO import StringIO
 from time import sleep
 from unittest import TestCase
+
 import logging
 
 
@@ -38,7 +40,7 @@ class TestProgressLogger(TestCase):
 
         with self.assertRaises(ValueError):
 
-            data = range(5)
+            data = list(range(5))
 
             with ProgressLogger('Bar', data, logger=self.logger,
                                 timeout=timeout) as step:
@@ -56,7 +58,7 @@ class TestProgressLogger(TestCase):
                          self.read_log())
 
     def test_accepts_iterable_object(self):
-        items = range(5)
+        items = list(range(5))
 
         with ProgressLogger('Foo', items, logger=self.logger) as step:
             for _item in items:
@@ -68,7 +70,7 @@ class TestProgressLogger(TestCase):
                          self.read_log())
 
     def test_acts_as_iterable_wrapper(self):
-        items = range(5)
+        items = list(range(5))
 
         result = []
 
@@ -85,7 +87,7 @@ class TestProgressLogger(TestCase):
             'Iterating over the progresslogger yields the original items.')
 
     def test_current_item_is_printed_when_logger_exits_unexpectedly(self):
-        items = range(5)
+        items = list(range(5))
 
         with self.assertRaises(ValueError):
             for item in ProgressLogger('Foo', items, logger=self.logger):

--- a/ftw/upgrade/tests/test_savepoint_iterator.py
+++ b/ftw/upgrade/tests/test_savepoint_iterator.py
@@ -19,7 +19,7 @@ class TestSavepointIterator(TestCase):
         os.environ.pop('UPGRADE_SAVEPOINT_THRESHOLD', None)
 
     def test_creates_savepoints(self):
-        self.assertEquals(
+        self.assertEqual(
             0, self.txn._savepoint_index,
             'A new transaction should not have any savepoints yet')
 
@@ -28,16 +28,16 @@ class TestSavepointIterator(TestCase):
         # Consume entire iterator
         result = list(iterator)
 
-        self.assertEquals(
+        self.assertEqual(
             self.iterable, result,
             'Iterator should yield every item of `iterable`')
 
-        self.assertEquals(
+        self.assertEqual(
             1, self.txn._savepoint_index,
             'One savepoint should have been created')
 
     def test_doesnt_create_savepoints_with_threshold_0(self):
-        self.assertEquals(
+        self.assertEqual(
             0, self.txn._savepoint_index,
             'A new transaction should not have any savepoints yet')
 
@@ -46,11 +46,11 @@ class TestSavepointIterator(TestCase):
         # Consume entire iterator
         result = list(iterator)
 
-        self.assertEquals(
+        self.assertEqual(
             self.iterable, result,
             'Iterator should yield every item of `iterable`')
 
-        self.assertEquals(
+        self.assertEqual(
             0, self.txn._savepoint_index,
             'threshold=0 should never create any savepoints')
 
@@ -63,11 +63,11 @@ class TestSavepointIterator(TestCase):
 
     def test_default_threshold_is_1000(self):
         # 1000 is the application default.
-        self.assertEquals(1000, SavepointIterator.get_default_threshold())
+        self.assertEqual(1000, SavepointIterator.get_default_threshold())
 
     def test_configure_default_threshold_with_environ_variable(self):
         os.environ['UPGRADE_SAVEPOINT_THRESHOLD'] = '333'
-        self.assertEquals(333, SavepointIterator.get_default_threshold())
+        self.assertEqual(333, SavepointIterator.get_default_threshold())
 
     def test_disable_default_threshold_with_environ_variable(self):
         os.environ['UPGRADE_SAVEPOINT_THRESHOLD'] = 'None'
@@ -79,4 +79,4 @@ class TestSavepointIterator(TestCase):
         os.environ['UPGRADE_SAVEPOINT_THRESHOLD'] = 'foo'
         with self.assertRaises(ValueError) as cm:
             SavepointIterator.get_default_threshold()
-        self.assertEquals("Invalid savepoint threshold 'foo'", str(cm.exception))
+        self.assertEqual("Invalid savepoint threshold 'foo'", str(cm.exception))

--- a/ftw/upgrade/tests/test_savepoint_iterator.py
+++ b/ftw/upgrade/tests/test_savepoint_iterator.py
@@ -1,6 +1,7 @@
 from ftw.upgrade.testing import UPGRADE_FUNCTIONAL_TESTING
 from ftw.upgrade.utils import SavepointIterator
 from unittest import TestCase
+
 import os
 import transaction
 

--- a/ftw/upgrade/tests/test_transactionnote.py
+++ b/ftw/upgrade/tests/test_transactionnote.py
@@ -1,7 +1,8 @@
 from ftw.upgrade.transactionnote import TransactionNote
+from six.moves import range
 from unittest import TestCase
-import transaction
 
+import transaction
 
 
 class TestTransactionNote(TestCase):

--- a/ftw/upgrade/tests/test_transactionnote.py
+++ b/ftw/upgrade/tests/test_transactionnote.py
@@ -28,7 +28,7 @@ class TestTransactionNote(TestCase):
 
     def test_description_is_removed_when_note_gets_too_long(self):
         # Transaction note size is limited to 65535 characters
-        description = 'A' * (65535 / 2)
+        description = 'A' * (65535 // 2)
 
         note = TransactionNote()
         note.add_upgrade('my.package:default', ('1000',), description)
@@ -52,7 +52,7 @@ class TestTransactionNote(TestCase):
         transaction.get().note('Some notes..')
 
         note = TransactionNote()
-        for destination in range(1, (65535 / len(profileid)) + 2):
+        for destination in range(1, (65535 // len(profileid)) + 2):
             note.add_upgrade(profileid, (str(destination),), '')
         note.set_transaction_note()
 

--- a/ftw/upgrade/tests/test_transactionnote.py
+++ b/ftw/upgrade/tests/test_transactionnote.py
@@ -21,7 +21,7 @@ class TestTransactionNote(TestCase):
         note.add_upgrade('my.package:default', ('1702',), 'Remove utility')
         note.set_transaction_note()
 
-        self.assertEquals(
+        self.assertEqual(
             u'my.package:default -> 1.1 (Migrate objects)\n'
             u'my.package:default -> 1702 (Remove utility)',
             transaction.get().description)
@@ -41,7 +41,7 @@ class TestTransactionNote(TestCase):
             'Description seems not to be removed from too long' + \
             ' transaction note.'
 
-        self.assertEquals(
+        self.assertEqual(
             u'my.package:default -> 1000\n'
             u'my.package:default -> 1001',
             transaction.get().description)

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -1,7 +1,7 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from DateTime import DateTime
 from datetime import datetime
+from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.upgrade import UpgradeStep
@@ -20,6 +20,7 @@ from unittest import skipIf
 from zope.interface import alsoProvides
 from zope.interface import Interface
 from zope.interface.verify import verifyClass
+
 import pkg_resources
 
 
@@ -966,11 +967,12 @@ class TestUpgradeStep(UpgradeTestCase):
                 permission, str(obj)))
 
     def get_not_acquired_permissions_of(self, obj):
-        acquired_permissions = filter(
-            lambda item: not item.get('acquire'),
-            obj.permission_settings())
+        acquired_permissions = [
+            item for item in obj.permission_settings()
+            if not item.get('acquire')
+        ]
 
-        return map(lambda item: item.get('name'), acquired_permissions)
+        return [item.get('name') for item in acquired_permissions]
 
     def get_allowed_roles_and_users_for(self, obj):
         processQueue()  # trigger async indexing

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -485,7 +485,7 @@ class TestUpgradeStep(UpgradeTestCase):
                 testcase.assertEqual(('foo', 'bar', 'baz'),
                                      self.portal.getProperty(key))
 
-                self.set_property(self.portal, key, ('foo'))
+                self.set_property(self.portal, key, ('foo',))
                 testcase.assertEqual(('foo',),
                                      self.portal.getProperty(key))
 
@@ -682,20 +682,20 @@ class TestUpgradeStep(UpgradeTestCase):
                     'Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow'))
 
     def test_uninstall_product(self):
-        quickinstaller = getToolByName(self.portal, 'portal_quickinstaller')
-        quickinstaller.installProduct('CMFPlacefulWorkflow')
-
-        def installed_products():
-            for product in quickinstaller.listInstalledProducts():
-                yield product['id']
+        quickinstaller = get_installer(self.portal, self.portal.REQUEST)
+        quickinstaller.install_product('CMFPlacefulWorkflow')
 
         class Step(UpgradeStep):
             def __call__(self):
                 self.uninstall_product('CMFPlacefulWorkflow')
 
-        self.assertIn('CMFPlacefulWorkflow', installed_products())
+        self.assertTrue(
+            quickinstaller.is_product_installed('CMFPlacefulWorkflow'),
+            'CMFPlacefulWorkflow should be installed')
         Step(self.portal_setup)
-        self.assertNotIn('CMFPlacefulWorkflow', installed_products())
+        self.assertFalse(
+            quickinstaller.is_product_installed('CMFPlacefulWorkflow'),
+            'CMFPlacefulWorkflow should not be installed')
 
     def test_migrate_class(self):
         folder = create(Builder('folder'))

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -20,8 +20,13 @@ from unittest import skipIf
 from zope.interface import alsoProvides
 from zope.interface import Interface
 from zope.interface.verify import verifyClass
+from Products.CMFPlone.utils import get_installer
 
 import pkg_resources
+
+ALLOWED_ROLES_AND_USERS_PERMISSION = 'View'
+if getFSVersionTuple() > (5, 2):
+    ALLOWED_ROLES_AND_USERS_PERMISSION = 'Access contents information'
 
 
 class IMyProductLayer(Interface):
@@ -836,7 +841,8 @@ class TestUpgradeStep(UpgradeTestCase):
                           self.get_allowed_roles_and_users_for(folder))
         folder.reindexObjectSecurity()
 
-        folder.manage_permission('View', roles=['Reader'], acquire=False)
+        folder.manage_permission(
+            ALLOWED_ROLES_AND_USERS_PERMISSION, roles=['Reader'], acquire=False)
         folder.reindexObjectSecurity()
 
         self.assertEquals(['Reader'],
@@ -859,7 +865,8 @@ class TestUpgradeStep(UpgradeTestCase):
         self.assertEquals(['Anonymous'],
                           self.get_allowed_roles_and_users_for(folder))
 
-        folder.manage_permission('View', roles=['Reader'], acquire=False)
+        folder.manage_permission(
+            ALLOWED_ROLES_AND_USERS_PERMISSION, roles=['Reader'], acquire=False)
         folder.reindexObjectSecurity()
 
         self.assertEquals(['Reader'],
@@ -894,7 +901,8 @@ class TestUpgradeStep(UpgradeTestCase):
                                 to_workflow='plone_workflow')
         folder = create(Builder('folder').in_state('published'))
 
-        folder.manage_permission('View', roles=['Reader'], acquire=False)
+        folder.manage_permission(
+            ALLOWED_ROLES_AND_USERS_PERMISSION, roles=['Reader'], acquire=False)
         folder.reindexObjectSecurity()
         self.assertEquals(['Reader'],
                           self.get_allowed_roles_and_users_for(folder))

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -103,12 +103,12 @@ class TestUpgradeStep(UpgradeTestCase):
 
         Step(self.portal_setup)
 
-        self.assertEquals(set(['Foo', 'Bar', 'Baz']), set(object_titles))
+        self.assertEqual(set(['Foo', 'Bar', 'Baz']), set(object_titles))
 
-        self.assertEquals(['STARTING Log message',
-                           '1 of 3 (33%): Log message',
-                           'DONE Log message'],
-                          self.get_log())
+        self.assertEqual(['STARTING Log message',
+                          '1 of 3 (33%): Log message',
+                          'DONE Log message'],
+                         self.get_log())
 
     def test_objects_modifying_catalog_does_not_reduce_result_set(self):
         old_date = DateTime(2010, 1, 1)
@@ -128,7 +128,7 @@ class TestUpgradeStep(UpgradeTestCase):
                     data['processed_folders'] += 1
 
         Step(self.portal_setup)
-        self.assertEquals(
+        self.assertEqual(
             4, data['processed_folders'],
             'Updating catalog reduced result set while iterating over it!!!')
 
@@ -208,13 +208,13 @@ class TestUpgradeStep(UpgradeTestCase):
 
                 brain = self.catalog_unrestricted_search(
                     {'UID': folder.UID()})[0]
-                testcase.assertEquals(modification_date, brain.modified)
+                testcase.assertEqual(modification_date, brain.modified)
 
                 self.catalog_reindex_objects({})
 
                 brain = self.catalog_unrestricted_search(
                     {'UID': folder.UID()})[0]
-                testcase.assertEquals(modification_date, brain.modified)
+                testcase.assertEqual(modification_date, brain.modified)
 
         Step(self.portal_setup)
 
@@ -287,7 +287,7 @@ class TestUpgradeStep(UpgradeTestCase):
 
             def __call__(self):
                 brains = self.get_folder_brains()
-                testcase.assertEquals(1, len(brains))
+                testcase.assertEqual(1, len(brains))
                 brain ,= brains
 
                 testcase.assertIsNone(
@@ -432,7 +432,7 @@ class TestUpgradeStep(UpgradeTestCase):
                 return [action.id for action in fti._actions]
 
             def __call__(self):
-                testcase.assertEquals(
+                testcase.assertEqual(
                     None, self.get_event_action('additional'))
                 testcase.assertNotIn(
                     'additional',
@@ -447,8 +447,8 @@ class TestUpgradeStep(UpgradeTestCase):
                     self.get_action_ids())
 
                 action = self.get_event_action('additional')
-                testcase.assertEquals('Additional', action.title)
-                testcase.assertEquals('string:#', action.action.text)
+                testcase.assertEqual('Additional', action.title)
+                testcase.assertEqual('string:#', action.action.text)
 
         Step(self.portal_setup)
 
@@ -558,20 +558,20 @@ class TestUpgradeStep(UpgradeTestCase):
 
         class Step(UpgradeStep):
             def __call__(self):
-                testcase.assertEquals(None, self.portal.getProperty('bar'))
-                testcase.assertEquals(None, self.portal.getProperty('foo'))
+                testcase.assertEqual(None, self.portal.getProperty('bar'))
+                testcase.assertEqual(None, self.portal.getProperty('foo'))
 
                 self.setup_install_profile('profile-the.package:foo')
-                testcase.assertEquals(None, self.portal.getProperty('bar'))
-                testcase.assertEquals('Foo', self.portal.getProperty('foo'))
+                testcase.assertEqual(None, self.portal.getProperty('bar'))
+                testcase.assertEqual('Foo', self.portal.getProperty('foo'))
 
                 self.portal._updateProperty('foo', 'Custom')
-                testcase.assertEquals(None, self.portal.getProperty('bar'))
-                testcase.assertEquals('Custom', self.portal.getProperty('foo'))
+                testcase.assertEqual(None, self.portal.getProperty('bar'))
+                testcase.assertEqual('Custom', self.portal.getProperty('foo'))
 
                 self.setup_install_profile('profile-the.package:bar')
-                testcase.assertEquals('Bar', self.portal.getProperty('bar'))
-                testcase.assertEquals(
+                testcase.assertEqual('Bar', self.portal.getProperty('bar'))
+                testcase.assertEqual(
                     'Custom', self.portal.getProperty('foo'),
                     'Accidental reinstall of dependency my.package:foo'
                     ' has caused the "foo" property to be reset.')
@@ -587,13 +587,13 @@ class TestUpgradeStep(UpgradeTestCase):
 
         class Step(UpgradeStep):
             def __call__(self):
-                testcase.assertEquals('unknown', self.get_version())
+                testcase.assertEqual('unknown', self.get_version())
                 self.ensure_profile_installed('profile-the.package:default')
-                testcase.assertEquals((u'1111',), self.get_version())
+                testcase.assertEqual((u'1111',), self.get_version())
                 self.set_version((u'1000',))
-                testcase.assertEquals((u'1000',), self.get_version())
+                testcase.assertEqual((u'1000',), self.get_version())
                 self.ensure_profile_installed('profile-the.package:default')
-                testcase.assertEquals(
+                testcase.assertEqual(
                     (u'1000',), self.get_version(),
                     'Profile should not have been installed again because it'
                     ' was already installed.')
@@ -847,24 +847,24 @@ class TestUpgradeStep(UpgradeTestCase):
         folder = create(Builder('folder')
                         .in_state('published'))
 
-        self.assertEquals(['Anonymous'],
-                          self.get_allowed_roles_and_users_for(folder))
+        self.assertEqual(['Anonymous'],
+                         self.get_allowed_roles_and_users_for(folder))
         folder.reindexObjectSecurity()
 
         folder.manage_permission(
             ALLOWED_ROLES_AND_USERS_PERMISSION, roles=['Reader'], acquire=False)
         folder.reindexObjectSecurity()
 
-        self.assertEquals(['Reader'],
-                          self.get_allowed_roles_and_users_for(folder))
+        self.assertEqual(['Reader'],
+                         self.get_allowed_roles_and_users_for(folder))
 
         class Step(UpgradeStep):
             def __call__(self):
                 self.update_security(folder)
         Step(self.portal_setup)
 
-        self.assertEquals(['Anonymous'],
-                          self.get_allowed_roles_and_users_for(folder))
+        self.assertEqual(['Anonymous'],
+                         self.get_allowed_roles_and_users_for(folder))
 
     def test_update_security_without_reindexing_security(self):
         self.set_workflow_chain(for_type='Folder',
@@ -872,23 +872,23 @@ class TestUpgradeStep(UpgradeTestCase):
         folder = create(Builder('folder')
                         .in_state('published'))
 
-        self.assertEquals(['Anonymous'],
-                          self.get_allowed_roles_and_users_for(folder))
+        self.assertEqual(['Anonymous'],
+                         self.get_allowed_roles_and_users_for(folder))
 
         folder.manage_permission(
             ALLOWED_ROLES_AND_USERS_PERMISSION, roles=['Reader'], acquire=False)
         folder.reindexObjectSecurity()
 
-        self.assertEquals(['Reader'],
-                          self.get_allowed_roles_and_users_for(folder))
+        self.assertEqual(['Reader'],
+                         self.get_allowed_roles_and_users_for(folder))
 
         class Step(UpgradeStep):
             def __call__(self):
                 self.update_security(folder, reindex_security=False)
         Step(self.portal_setup)
 
-        self.assertEquals(['Reader'],
-                          self.get_allowed_roles_and_users_for(folder))
+        self.assertEqual(['Reader'],
+                         self.get_allowed_roles_and_users_for(folder))
 
     def test_update_workflow_security_updates_security(self):
         self.set_workflow_chain(for_type='Folder',
@@ -914,8 +914,8 @@ class TestUpgradeStep(UpgradeTestCase):
         folder.manage_permission(
             ALLOWED_ROLES_AND_USERS_PERMISSION, roles=['Reader'], acquire=False)
         folder.reindexObjectSecurity()
-        self.assertEquals(['Reader'],
-                          self.get_allowed_roles_and_users_for(folder))
+        self.assertEqual(['Reader'],
+                         self.get_allowed_roles_and_users_for(folder))
 
         class Step(UpgradeStep):
             def __call__(self):
@@ -923,8 +923,8 @@ class TestUpgradeStep(UpgradeTestCase):
                     ['plone_workflow'], reindex_security=False)
         Step(self.portal_setup)
 
-        self.assertEquals(['Reader'],
-                          self.get_allowed_roles_and_users_for(folder))
+        self.assertEqual(['Reader'],
+                         self.get_allowed_roles_and_users_for(folder))
 
         class Step(UpgradeStep):
             def __call__(self):
@@ -932,8 +932,8 @@ class TestUpgradeStep(UpgradeTestCase):
                     ['plone_workflow'], reindex_security=True)
         Step(self.portal_setup)
 
-        self.assertEquals(['Anonymous'],
-                          self.get_allowed_roles_and_users_for(folder))
+        self.assertEqual(['Anonymous'],
+                         self.get_allowed_roles_and_users_for(folder))
 
     def test_update_workflow_security_expects_list_of_workflows(self):
         class Step(UpgradeStep):
@@ -943,8 +943,8 @@ class TestUpgradeStep(UpgradeTestCase):
         with self.assertRaises(ValueError) as cm:
             Step(self.portal_setup)
 
-        self.assertEquals('"workflows" must be a list of workflow names.',
-                          str(cm.exception))
+        self.assertEqual('"workflows" must be a list of workflow names.',
+                         str(cm.exception))
 
     def test_base_profile_and_target_version_are_stored_in_attribute(self):
         result = {}
@@ -958,7 +958,7 @@ class TestUpgradeStep(UpgradeTestCase):
              base_profile='profile-ftw.upgrade:default',
              target_version=1500)
 
-        self.assertEquals(
+        self.assertEqual(
             {'base_profile': 'profile-ftw.upgrade:default',
              'target_version': 1500},
             result)

--- a/ftw/upgrade/tests/test_utils.py
+++ b/ftw/upgrade/tests/test_utils.py
@@ -12,6 +12,7 @@ from six.moves import map
 from six.moves import range
 from unittest import TestCase
 
+import six
 import stat
 
 
@@ -166,8 +167,8 @@ class TestSortedProfileIds(MockTestCase):
         with self.assertRaises(CyclicDependencies) as cm:
             get_sorted_profile_ids(portal_setup)
 
-        self.assertEqual([('foo', 'bar')],
-                         cm.exception.cyclic_dependencies)
+        six.assertCountEqual(
+            self, ('foo', 'bar'), cm.exception.cyclic_dependencies[0])
 
         self.assertEqual([('foo', 'bar'), ('bar', 'foo')],
                          cm.exception.dependencies)

--- a/ftw/upgrade/tests/test_utils.py
+++ b/ftw/upgrade/tests/test_utils.py
@@ -267,7 +267,7 @@ class TestGetTempfileAuthenticationDirectory(TestCase):
     def setUp(self):
         self.buildoutdir = self.layer['temp_directory']
         self.buildoutdir.joinpath('bin').mkdir()
-        self.buildoutdir.joinpath('bin', 'buildout').write_bytes('')
+        self.buildoutdir.joinpath('bin', 'buildout').write_bytes(b'')
         self.buildoutdir.joinpath('var').mkdir()
 
     def test_directory_is_created(self):

--- a/ftw/upgrade/tests/test_utils.py
+++ b/ftw/upgrade/tests/test_utils.py
@@ -81,7 +81,7 @@ class TestFindCyclicDependencies(TestCase):
             ('default', 'image-replacement'),
             )
 
-        self.assertEquals(
+        self.assertEqual(
             [set(('foo', 'bar'))],
             list(map(set, find_cyclic_dependencies(dependencies))))
 
@@ -92,7 +92,7 @@ class TestFindCyclicDependencies(TestCase):
             ('baz', 'foo'),
             )
 
-        self.assertEquals(
+        self.assertEqual(
             [set(('foo', 'bar', 'baz'))],
             list(map(set, find_cyclic_dependencies(dependencies))))
 
@@ -238,22 +238,22 @@ class TestFormatDuration(TestCase):
 class TestSubjectFromDocstring(TestCase):
 
     def test_one_line_only(self):
-        self.assertEquals(
+        self.assertEqual(
             'This is the subject.',
             subject_from_docstring('This is the subject.'))
 
     def test_whitespace_is_stripped(self):
-        self.assertEquals(
+        self.assertEqual(
             'This is the subject.',
             subject_from_docstring('\nThis is the subject.\n'))
 
     def test_only_subject_is_returned(self):
-        self.assertEquals(
+        self.assertEqual(
             'This is the subject.',
             subject_from_docstring('This is the subject.\n\nThis is the body.'))
 
     def test_multiline_subject_is_joined(self):
-        self.assertEquals(
+        self.assertEqual(
             'This is a subject, with multiple lines.',
             subject_from_docstring('This is a subject,\n'
                                    'with multiple lines.\n'

--- a/ftw/upgrade/tests/test_utils.py
+++ b/ftw/upgrade/tests/test_utils.py
@@ -8,7 +8,10 @@ from ftw.upgrade.utils import get_tempfile_authentication_directory
 from ftw.upgrade.utils import SizedGenerator
 from ftw.upgrade.utils import subject_from_docstring
 from ftw.upgrade.utils import topological_sort
+from six.moves import map
+from six.moves import range
 from unittest import TestCase
+
 import stat
 
 
@@ -78,9 +81,8 @@ class TestFindCyclicDependencies(TestCase):
             )
 
         self.assertEquals(
-            [set(('foo',
-                  'bar'))],
-            map(set, find_cyclic_dependencies(dependencies)))
+            [set(('foo', 'bar'))],
+            list(map(set, find_cyclic_dependencies(dependencies))))
 
     def test_indirect_cyclic_dependencies(self):
         dependencies = (
@@ -90,10 +92,8 @@ class TestFindCyclicDependencies(TestCase):
             )
 
         self.assertEquals(
-            [set(('foo',
-                  'bar',
-                  'baz'))],
-            map(set, find_cyclic_dependencies(dependencies)))
+            [set(('foo', 'bar', 'baz'))],
+            list(map(set, find_cyclic_dependencies(dependencies))))
 
 
 class TestSizedGenerator(TestCase):

--- a/ftw/upgrade/tests/test_workflow.py
+++ b/ftw/upgrade/tests/test_workflow.py
@@ -76,7 +76,7 @@ class TestWorkflowChainUpdater(WorkflowTestCase):
             self.set_workflow_chain(for_type='Folder',
                                     to_workflow='plone_workflow')
 
-        self.assertEquals(
+        self.assertEqual(
             ['Anonymous'],
             self.get_allowed_roles_and_users(for_object=container))
 
@@ -190,7 +190,7 @@ class TestWorkflowChainUpdater(WorkflowTestCase):
     def assert_workflow_history_length(self, context, length):
         wftool = getToolByName(self.layer['portal'], 'portal_workflow')
         history = wftool.getInfoFor(context, 'review_history')
-        self.assertEquals(
+        self.assertEqual(
             length, len(history),
             'Workflow history length is wrong.\n{0}'.format(history))
 
@@ -229,17 +229,17 @@ class TestWorkflowSecurityUpdater(WorkflowTestCase):
         folder.manage_permission(
             ALLOWED_ROLES_AND_USERS_PERMISSION, roles=['Reader'], acquire=False)
         folder.reindexObjectSecurity()
-        self.assertEquals(['Reader'],
-                          self.get_allowed_roles_and_users(for_object=folder))
+        self.assertEqual(['Reader'],
+                         self.get_allowed_roles_and_users(for_object=folder))
 
         updater = WorkflowSecurityUpdater()
         updater.update(['folder_workflow'], reindex_security=False)
-        self.assertEquals(['Reader'],
-                          self.get_allowed_roles_and_users(for_object=folder))
+        self.assertEqual(['Reader'],
+                         self.get_allowed_roles_and_users(for_object=folder))
 
         updater.update(['folder_workflow'], reindex_security=True)
-        self.assertEquals(['Anonymous'],
-                          self.get_allowed_roles_and_users(for_object=folder))
+        self.assertEqual(['Anonymous'],
+                         self.get_allowed_roles_and_users(for_object=folder))
 
     def test_respects_placeful_workflows_when_updating(self):
         container = create(Builder('folder'))

--- a/ftw/upgrade/tests/test_workflow.py
+++ b/ftw/upgrade/tests/test_workflow.py
@@ -5,6 +5,11 @@ from ftw.upgrade.tests.base import WorkflowTestCase
 from ftw.upgrade.workflow import WorkflowChainUpdater
 from ftw.upgrade.workflow import WorkflowSecurityUpdater
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import getFSVersionTuple
+
+ALLOWED_ROLES_AND_USERS_PERMISSION = 'View'
+if getFSVersionTuple() > (5, 2):
+    ALLOWED_ROLES_AND_USERS_PERMISSION = 'Access contents information'
 
 
 class TestWorkflowChainUpdater(WorkflowTestCase):
@@ -221,7 +226,8 @@ class TestWorkflowSecurityUpdater(WorkflowTestCase):
         self.set_workflow_chain(for_type='Folder',
                                 to_workflow='folder_workflow')
         folder = create(Builder('folder'))
-        folder.manage_permission('View', roles=['Reader'], acquire=False)
+        folder.manage_permission(
+            ALLOWED_ROLES_AND_USERS_PERMISSION, roles=['Reader'], acquire=False)
         folder.reindexObjectSecurity()
         self.assertEquals(['Reader'],
                           self.get_allowed_roles_and_users(for_object=folder))

--- a/ftw/upgrade/utils.py
+++ b/ftw/upgrade/utils.py
@@ -3,7 +3,9 @@ from contextlib import contextmanager
 from copy import deepcopy
 from ftw.upgrade.exceptions import CyclicDependencies
 from path import Path
+from six.moves import map
 from zope.component.hooks import getSite
+
 import logging
 import math
 import os
@@ -266,7 +268,7 @@ def subject_from_docstring(docstring):
     The subject consists of all lines from the beginning to the
     first empty line. Newlines are stripped.
     """
-    lines = map(str.strip, docstring.strip().splitlines())
+    lines = list(map(str.strip, docstring.strip().splitlines()))
     try:
         lines.index('')
     except ValueError:
@@ -288,7 +290,7 @@ def get_tempfile_authentication_directory(directory=None):
 
     auth_directory = directory.joinpath('var', 'ftw.upgrade-authentication')
     if not auth_directory.isdir():
-        auth_directory.mkdir(mode=0770)
+        auth_directory.mkdir(mode=0o770)
 
     # Verify that "others" do not have any permissions on this directory.
     if auth_directory.stat().st_mode & stat.S_IRWXO:

--- a/ftw/upgrade/workflow.py
+++ b/ftw/upgrade/workflow.py
@@ -1,11 +1,15 @@
 from DateTime import DateTime
-from Products.CMFCore.utils import getToolByName
 from ftw.upgrade import ProgressLogger
 from ftw.upgrade.helpers import update_security_for
 from ftw.upgrade.utils import SavepointIterator
 from ftw.upgrade.utils import SizedGenerator
+from Products.CMFCore.utils import getToolByName
+from six.moves import map
+from six.moves import zip
 from zope.component.hooks import getSite
+
 import logging
+
 
 LOG = logging.getLogger('ftw.upgrade.WorkflowChainUpdater')
 
@@ -72,7 +76,7 @@ class WorkflowChainUpdater(object):
 
         portal = getSite()
         wf_tool = getToolByName(portal, 'portal_workflow')
-        origin_workflows = zip(*self.review_state_mapping.keys())[0]
+        origin_workflows = list(zip(*list(self.review_state_mapping.keys())))[0]
 
         title = 'Change workflow states'
         for path in ProgressLogger(title, status_before_activation):
@@ -148,7 +152,7 @@ class WorkflowChainUpdater(object):
             _migrate_action(entry)
             return entry
 
-        wfhistory[new_wf] = map(_migrate_entry, wfhistory[old_wf])
+        wfhistory[new_wf] = list(map(_migrate_entry, wfhistory[old_wf]))
 
 
 class WorkflowSecurityUpdater(object):
@@ -203,6 +207,5 @@ class WorkflowSecurityUpdater(object):
 
     def obj_has_workflow(self, obj, workflows):
         wftool = getToolByName(getSite(), 'portal_workflow')
-        obj_workflow_names = map(lambda wf: wf.getId(),
-                                 wftool.getWorkflowsFor(obj))
+        obj_workflow_names = [wf.getId() for wf in wftool.getWorkflowsFor(obj)]
         return set(obj_workflow_names) & set(workflows)

--- a/ftw/upgrade/zcml.py
+++ b/ftw/upgrade/zcml.py
@@ -6,6 +6,7 @@ from Products.GenericSetup.zcml import upgradeStep
 from zope.configuration.fields import GlobalObject
 from zope.configuration.fields import Path
 from zope.interface import Interface
+
 import zope.schema
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ tests_require = [
     ]
 
 extras_require = {
-    'colors': ['blessed <= 1.9.5'],
+    'colors': ['blessed'],
     'tests': tests_require,
     'test_archetypes': ['Products.ATContentTypes'],
 }

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,14 @@ tests_require = [
     'zope.configuration',
     'zc.recipe.egg',
     'transaction',
-    'Products.ATContentTypes',
     'Products.CMFPlacefulWorkflow',
     ]
 
 extras_require = {
     'colors': ['blessed <= 1.9.5'],
-    'tests': tests_require}
+    'tests': tests_require,
+    'test_archetypes': ['Products.ATContentTypes'],
+}
 
 setup(name='ftw.upgrade',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
 import os
 
-version = '2.16.1.dev0'
+version = '3.0.0.dev0'
 
 tests_require = [
-    'ftw.testing >= 1.8.1',
-    'ftw.testbrowser',
-    'ftw.builder >= 1.6.0',
+    'ftw.testing >= 2.0.0.dev0',
+    'ftw.testbrowser >= 2.1.0.dev0',
+    'ftw.builder >= 2.0.0.dev0',
     'plone.testing',
     'plone.app.testing',
     'plone.app.intid',
@@ -36,6 +36,10 @@ setup(name='ftw.upgrade',
         'Framework :: Plone',
         'Framework :: Plone :: 4.3',
         'Framework :: Plone :: 5.1',
+        'Framework :: Plone :: 5.2',
+        'Programming Language :: Python',
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.7",
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Programming Language :: Python',

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -3,7 +3,7 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
 
 package-name = ftw.upgrade
-
+test-extras = tests, test_archetypes
 
 [test]
 eggs += plone4.csrffixes

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -2,3 +2,4 @@
 extends = https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
 
 package-name = ftw.upgrade
+test-extras = tests, test_archetypes

--- a/test-plone-5.2.x-py37.cfg
+++ b/test-plone-5.2.x-py37.cfg
@@ -1,0 +1,4 @@
+[buildout]
+extends = https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x-py37.cfg
+
+package-name = ftw.upgrade

--- a/test-plone-5.2.x-py37.cfg
+++ b/test-plone-5.2.x-py37.cfg
@@ -6,3 +6,4 @@ package-name = ftw.upgrade
 [versions]
 # Fixes issue with sorting of upgrade steps
 Products.GenericSetup = 2.0.1
+importlib-metadata = 0.23

--- a/test-plone-5.2.x-py37.cfg
+++ b/test-plone-5.2.x-py37.cfg
@@ -4,6 +4,4 @@ extends = https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x
 package-name = ftw.upgrade
 
 [versions]
-# Fixes issue with sorting of upgrade steps
-Products.GenericSetup = 2.0.1
 importlib-metadata = 0.23

--- a/test-plone-5.2.x-py37.cfg
+++ b/test-plone-5.2.x-py37.cfg
@@ -2,3 +2,7 @@
 extends = https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x-py37.cfg
 
 package-name = ftw.upgrade
+
+[versions]
+# Fixes issue with sorting of upgrade steps
+Products.GenericSetup = 2.0.1

--- a/test-plone-5.2.x.cfg
+++ b/test-plone-5.2.x.cfg
@@ -6,3 +6,4 @@ package-name = ftw.upgrade
 [versions]
 # Fixes issue with sorting of upgrade steps
 Products.GenericSetup = 2.0.1
+importlib-metadata = 0.23

--- a/test-plone-5.2.x.cfg
+++ b/test-plone-5.2.x.cfg
@@ -4,6 +4,4 @@ extends = https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x
 package-name = ftw.upgrade
 
 [versions]
-# Fixes issue with sorting of upgrade steps
-Products.GenericSetup = 2.0.1
 importlib-metadata = 0.23

--- a/test-plone-5.2.x.cfg
+++ b/test-plone-5.2.x.cfg
@@ -1,0 +1,4 @@
+[buildout]
+extends = https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x.cfg
+
+package-name = ftw.upgrade

--- a/test-plone-5.2.x.cfg
+++ b/test-plone-5.2.x.cfg
@@ -2,3 +2,7 @@
 extends = https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x.cfg
 
 package-name = ftw.upgrade
+
+[versions]
+# Fixes issue with sorting of upgrade steps
+Products.GenericSetup = 2.0.1


### PR DESCRIPTION
Adds support for Plone 5.2 and Python 3

Mainly compatibility fixes. Uses Plone's `installer` view [PLIP 1340](https://github.com/plone/Products.CMFPlone/issues/1340) if available and falls back to QuickInstaller if not.