### PR TITLE
Add "six" to the list of dependencies.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- This Plone add-on now requires six >= 1.12.0. [mbaechtold]
 
 
 3.0.0 (2020-03-23)

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(name='ftw.upgrade',
         'path.py >= 6.2',
         'requests',
         'setuptools',
+        'six >= 1.12.0',
         'tarjan',
 
         # Zope


### PR DESCRIPTION
`ftw.upgrade` makes use of `six` a lot, but it was not declared as a direct dependency in `setup.py` until now.

Closes https://github.com/4teamwork/ftw.upgrade/issues/198