### PR TITLE
Instance port number discovery with fast-listen

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,9 @@ Changelog
 ------------------
 
 - This Plone add-on now requires six >= 1.12.0. [mbaechtold]
+- Instance port number discovery in ``wsgi.ini`` works also when the fast listen
+  option is choosen.
+  Fixes `issue 200 <https://github.com/4teamwork/ftw.upgrade/issues/200>`. [ale-rt]
 
 
 3.0.0 (2020-03-23)

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -232,6 +232,10 @@ def get_instance_port(zconf):
     match = re.search(r'\slisten = ([\d.]*:)?(\d+)', zconf.text())
     if match:
         return int(match.group(2))
+    # wsgi.ini with fast listen
+    match = re.search(r'\sfast-listen = ([\d.]*:)?(\d+)', zconf.text())
+    if match:
+        return int(match.group(2))
     return None
 
 

--- a/ftw/upgrade/tests/test_command_jsonapi.py
+++ b/ftw/upgrade/tests/test_command_jsonapi.py
@@ -199,3 +199,13 @@ class TestJsonAPIUtils(CommandAndInstanceTestCase):
         zconf = ZopeConfPathStub('<http-server>',
                                  '</http-server>')
         self.assertEqual(None, get_instance_port(zconf))
+
+    def test_get_instance_port_wsgi_listen(self):
+        zconf = ZopeConfPathStub('[server:main]\n'
+                                 'listen = 127.0.0.1:8080')
+        self.assertEqual(8080, get_instance_port(zconf))
+
+    def test_get_instance_port_wsgi_fast_listen(self):
+        zconf = ZopeConfPathStub('[server:main]\n'
+                                 'fast-listen = 0.0.0.0:8080')
+        self.assertEqual(8080, get_instance_port(zconf))


### PR DESCRIPTION
Instance port number discovery in ``wsgi.ini`` works also when the
fast listen option is choosen.

Fixes #200