### PR TITLE
Check for six.binary_type to avoid AttributeErrors when running under python3

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Check for six.binary_type to avoid AttributeErrors when running under Python3.
+  [erral]
 
 
 3.0.1 (2020-06-09)

--- a/ftw/upgrade/migration.py
+++ b/ftw/upgrade/migration.py
@@ -407,7 +407,7 @@ class InplaceMigrator(object):
         recurse = partial(self.normalize_at_field_value,
                           old_field, old_fieldname)
 
-        if isinstance(value, str):
+        if isinstance(value, six.binary_type):
             return recurse(value.decode('utf-8'))
 
         if isinstance(value, list):
@@ -448,7 +448,7 @@ class InplaceMigrator(object):
     def prepare_field_value(self, new_object, field, value):
         recurse = partial(self.prepare_field_value, new_object, field)
 
-        if isinstance(value, str):
+        if isinstance(value, six.binary_type):
             return recurse(value.decode('utf-8'))
 
         if isinstance(value, list):
@@ -485,7 +485,7 @@ class InplaceMigrator(object):
 
             if source_is_blobby and target_is_blobby:
                 filename = value.filename
-                if isinstance(filename, str):
+                if isinstance(filename, six.binary_type):
                     filename = filename.decode('utf-8')
 
                 new_value = field._type(
@@ -507,7 +507,7 @@ class InplaceMigrator(object):
 
             else:
                 filename = value.filename
-                if isinstance(filename, str):
+                if isinstance(filename, six.binary_type):
                     filename = filename.decode('utf-8')
 
                 data = value.data


### PR DESCRIPTION
When using ftw.upgrade to run a upgrade_step in Plone 5.2 and python3 to migrate some contents to another content-type, I run into this error:

```
2020-07-16 10:54:26,954 ERROR   [ftw.upgrade:39][waitress] FAILED
Traceback (most recent call last):
  File "/home/erral/downloads/eggs/ftw.upgrade-3.0.1-py3.7.egg/ftw/upgrade/jsonapi/plonesite.py", line 196, in _install_upgrades
    *api_ids, propose_deferrable=propose_deferrable)
  File "/home/erral/downloads/eggs/ftw.upgrade-3.0.1-py3.7.egg/ftw/upgrade/executioner.py", line 62, in install_upgrades_by_api_ids
    return self.install(data)
  File "/home/erral/downloads/eggs/ftw.upgrade-3.0.1-py3.7.egg/ftw/upgrade/executioner.py", line 48, in install
    self._upgrade_profile(profileid, upgradeids)
  File "/home/erral/downloads/eggs/ftw.upgrade-3.0.1-py3.7.egg/ftw/upgrade/executioner.py", line 111, in _upgrade_profile
    last_dest_version = self._do_upgrade(profileid, upgradeid) \
  File "/home/erral/downloads/eggs/ftw.upgrade-3.0.1-py3.7.egg/ftw/upgrade/executioner.py", line 151, in _do_upgrade
    step.doStep(self.portal_setup)
  File "/home/erral/downloads/eggs/Products.GenericSetup-2.0.1-py3.7.egg/Products/GenericSetup/upgrade.py", line 168, in doStep
    self.handler(tool)
  File "/home/erral/downloads/eggs/ftw.upgrade-3.0.1-py3.7.egg/ftw/upgrade/step.py", line 60, in __new__
    return obj()
  File "/home/erral/dev/xxx.buildout/src/xxx.addon/src/xxx/addon/upgrades/v1004.py", line 32, in __call__
    migrator.migrate_object(obj)
  File "/home/erral/downloads/eggs/ftw.upgrade-3.0.1-py3.7.egg/ftw/upgrade/migration.py", line 234, in migrate_object
    + list(self.final_steps)))
  File "/home/erral/downloads/eggs/ftw.upgrade-3.0.1-py3.7.egg/ftw/upgrade/migration.py", line 231, in &lt;lambda&gt;
    list(map(lambda func: func(old_object, new_object),
  File "/home/erral/downloads/eggs/ftw.upgrade-3.0.1-py3.7.egg/ftw/upgrade/migration.py", line 346, in migrate_field_values
    self.set_field_value(new_object, new_field, value)
  File "/home/erral/downloads/eggs/ftw.upgrade-3.0.1-py3.7.egg/ftw/upgrade/migration.py", line 445, in set_field_value
    value = self.prepare_field_value(new_object, field, value)
  File "/home/erral/downloads/eggs/ftw.upgrade-3.0.1-py3.7.egg/ftw/upgrade/migration.py", line 452, in prepare_field_value
    return recurse(value.decode('utf-8'))
AttributeError: 'str' object has no attribute 'decode'

```

The code asumes that the item should be a `str` but in python3 `str` objects have no `decode`, so I think that the check should be for `six.binary_type`. With this change, the upgrade can be run without issues.