### PR TITLE
Do not depend anymore on argparse

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 3.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not depend anymore on argparse because it is already included in
+  Python 2.7 and in Python 3 since version 3.2
+  Fixes `issue 209 <https://github.com/4teamwork/ftw.upgrade/issues/209>`.
+  [ale-rt]
 
 
 3.0.2 (2020-08-27)

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(name='ftw.upgrade',
 
       install_requires=[
         'argcomplete',
-        'argparse',
         'inflection',
         'path.py >= 6.2',
         'requests',


### PR DESCRIPTION
Do not depend anymore on argparse because it is already included in
Python 2.7 and in Python 3 since version 3.2
Fixes #209