### PR TITLE
Use importlib when on Python3

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,11 @@ Changelog
 3.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- When using Python3, use importlib instead of the deprecated imp module
+  to look for upgrade steps.
+  This removes the warning displayed about unclosed resources.
+  Fixes `issue 211 <https://github.com/4teamwork/ftw.upgrade/issues/211>`.
+  [ale-rt]
 
 
 3.0.3 (2020-10-10)

--- a/ftw/upgrade/tests/test_directory_scanner.py
+++ b/ftw/upgrade/tests/test_directory_scanner.py
@@ -7,6 +7,9 @@ from ftw.upgrade.exceptions import UpgradeStepDefinitionError
 from ftw.upgrade.tests.base import UpgradeTestCase
 from six.moves import map
 
+import six
+import unittest
+
 
 class TestDirectoryScanner(UpgradeTestCase):
 
@@ -47,7 +50,10 @@ class TestDirectoryScanner(UpgradeTestCase):
 
                 upgrade_infos)
 
-    def test_exception_raised_when_upgrade_has_no_code(self):
+    @unittest.skipUnless(
+        six.PY2, "Loading upgrades uses a deprecated library in Python2.7"
+    )
+    def test_exception_raised_when_upgrade_has_no_code_py27(self):
         self.profile.with_upgrade(Builder('ftw upgrade step')
                                   .to(datetime(2011, 1, 1, 8))
                                   .named('add action')
@@ -62,7 +68,10 @@ class TestDirectoryScanner(UpgradeTestCase):
             ' in the upgrade.py module.',
             str(cm.exception))
 
-    def test_exception_raised_when_multiple_upgrade_steps_detected(self):
+    @unittest.skipUnless(
+        six.PY2, "Loading upgrades uses a deprecated library in Python2.7"
+    )
+    def test_exception_raised_when_multiple_upgrade_steps_detected_py27(self):
         code = '\n'.join((
                 'from ftw.upgrade import UpgradeStep',
                 'class Foo(UpgradeStep): pass',
@@ -81,6 +90,45 @@ class TestDirectoryScanner(UpgradeTestCase):
             'The upgrade step 20110101080000_add_action has more than one upgrade'
             ' class in the upgrade.py module.',
             str(cm.exception))
+
+    @unittest.skipIf(
+        six.PY2, "Loading upgrades uses a deprecated library in Python2.7"
+    )
+    def test_exception_raised_when_upgrade_has_no_code(self):
+        self.profile.with_upgrade(Builder('ftw upgrade step')
+                                  .to(datetime(2011, 1, 1, 8))
+                                  .named('add action')
+                                  .with_code(''))
+
+        with create(self.package) as package:
+            with self.assertRaises(UpgradeStepDefinitionError) as cm:
+                self.scan(package)
+        self.assertRegex(
+            str(cm.exception),
+            "The upgrade step file (.*)upgrade.py has no upgrade class."  # noqa: E501
+        )
+
+    @unittest.skipIf(
+        six.PY2, "Loading upgrades uses a deprecated library in Python2.7"
+    )
+    def test_exception_raised_when_multiple_upgrade_steps_detected(self):
+        code = '\n'.join((
+                'from ftw.upgrade import UpgradeStep',
+                'class Foo(UpgradeStep): pass',
+                'class Bar(UpgradeStep): pass'))
+
+        self.profile.with_upgrade(Builder('ftw upgrade step')
+                                  .to(datetime(2011, 1, 1, 8))
+                                  .named('add action')
+                                  .with_code(code))
+
+        with create(self.package) as package:
+            with self.assertRaises(UpgradeStepDefinitionError) as cm:
+                self.scan(package)
+        self.assertRegex(
+            str(cm.exception),
+            "The upgrade step file (.*)upgrade.py has more than one upgrade class."  # noqa: E501
+        )
 
     def test_does_not_fail_when_no_upgrades_present(self):
         self.package.with_zcml_include('ftw.upgrade', file='meta.zcml')


### PR DESCRIPTION
Remove the warnings:
```
.../ftw.upgrade/ftw/upgrade/directory/scanner.py:10: DeprecationWarning: the imp module is deprecated in favour of importlib; 
.../ftw.upgrade/ftw/upgrade/directory/scanner.py:40: ResourceWarning: unclosed file ...
```
when using ftw.upgrade on Python3.

Fixes #211 