### PR TITLE
Do not call cookResources on dummy old resource registry tools.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 3.0.4 (unreleased)
 ------------------
 
+- Do not call ``cookResources`` on dummy old resource registry tools.  [maurits]
+
 - When using Python3, use importlib instead of the deprecated imp module
   to look for upgrade steps.
   This removes the warning displayed about unclosed resources.

--- a/ftw/upgrade/resource_registries.py
+++ b/ftw/upgrade/resource_registries.py
@@ -7,7 +7,8 @@ from zope.component.hooks import getSite
 def recook_resources():
     for name in ('portal_css', 'portal_javascripts'):
         registry = getToolByName(getSite(), name, None)
-        if registry is not None:
+        # Tool might not be there, or might be a dummy alias from plone.app.upgrade.
+        if registry is not None and hasattr(registry, 'cookResources'):
             registry.cookResources()
 
     # Plone 5: clear all bundles


### PR DESCRIPTION
I see this when migrating from Plone 4.3 to 5.2 when I want to run a small upgrade step before doing the plone-upgrade:

```
$ bin/upgrade install --site minaraad --allow-outdated --upgrades 5200@Products.minaraad:default
2021-01-05 10:22:17,980 INFO    [ftw.upgrade:147][waitress-0] ______________________________________________________________________
2021-01-05 10:22:17,981 INFO    [ftw.upgrade:149][waitress-0] UPGRADE STEP Products.minaraad:default: Pre 5.2 cleanup
2021-01-05 10:22:17,982 INFO    [ftw.upgrade:156][waitress-0] Ran upgrade step Pre 5.2 cleanup for profile Products.minaraad:default
2021-01-05 10:22:17,982 INFO    [ftw.upgrade:159][waitress-0] Upgrade step duration: 1 second
2021-01-05 10:22:17,987 ERROR   [ftw.upgrade:39][waitress-0] FAILED
Traceback (most recent call last):
  File "/Users/maurits/shared-eggs/cp27m/ftw.upgrade-3.0.3-py2.7.egg/ftw/upgrade/jsonapi/plonesite.py", line 196, in _install_upgrades
    *api_ids, propose_deferrable=propose_deferrable)
  File "/Users/maurits/shared-eggs/cp27m/ftw.upgrade-3.0.3-py2.7.egg/ftw/upgrade/executioner.py", line 62, in install_upgrades_by_api_ids
    return self.install(data)
  File "/Users/maurits/shared-eggs/cp27m/ftw.upgrade-3.0.3-py2.7.egg/ftw/upgrade/executioner.py", line 54, in install
    recook_resources()
  File "/Users/maurits/shared-eggs/cp27m/ftw.upgrade-3.0.3-py2.7.egg/ftw/upgrade/resource_registries.py", line 11, in recook_resources
    registry.cookResources()
AttributeError: 'RequestContainer' object has no attribute 'cookResources'
Result: FAILURE
```

This is because `portal_css` and `portal_javascripts` are still there, but are dummy aliases from plone.app.upgrade.