### PR TITLE
Add intermediate commit option to commit the transaction after each installed upgrade.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ Some examples:
     $ bin/upgrade touch my/package/upgrades/20110101000000_add_catalog_index
     $ bin/upgrade sites
     $ bin/upgrade list -s Plone --auth admin:admin --upgrades
-    $ bin/upgrade install -s Plone --auth admin:admin  --proposed
+    $ bin/upgrade install -s Plone --auth admin:admin  --proposed --intermediate-commit
 
 The full documentation of the ``bin/upgrade`` script is available using its help system:
 
@@ -1073,6 +1073,12 @@ Example for executing all proposed upgrades of a Plone site:
     2015-01-14 11:17:35 INFO ftw.upgrade Ran upgrade step Bar. for profile ftw.upgrade:default
     2015-01-14 11:17:35 INFO ftw.upgrade Upgrade step duration: 1 second
     Result: SUCCESS
+
+To commit after each upgrade, pass the ``intermediate_commit`` argument:
+
+.. code:: sh
+
+    $ curl -uadmin:admin -X POST http://localhost:8080/Plone/upgrades-api/execute_proposed_upgrades?intermediate_commit=true
 
 
 Installing profiles

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add intermediate commit option to commit the transaction after each installed upgrade. [deiferni]
 
 
 3.0.4 (2021-01-21)

--- a/ftw/upgrade/command/install.py
+++ b/ftw/upgrade/command/install.py
@@ -110,6 +110,12 @@ def setup_argparser(commands):
                          dest='allow_outdated',
                          action='store_true')
 
+    command.add_argument('--intermediate-commit',
+                         help='Commit after installing an upgrade step.',
+                         default=False,
+                         dest='intermediate_commit',
+                         action='store_true')
+
 
 @with_api_requestor
 @error_handling
@@ -124,6 +130,10 @@ def install_command(args, requestor):
         if args.skip_deferrable:
             params.append(('propose_deferrable', False))
     elif args.profiles:
+        if args.intermediate_commit:
+            print('ERROR: --intermediate-commit is not implemented for --profiles.',
+                  file=sys.stderr)
+            sys.exit(3)
         action = 'execute_profiles'
         params = [('profiles:list', name) for name in set(args.profiles)]
         if args.force_reinstall:
@@ -133,6 +143,8 @@ def install_command(args, requestor):
         params = [('upgrades:list', name) for name in set(args.upgrades)]
     if args.allow_outdated:
         params.append(('allow_outdated', True))
+    if args.intermediate_commit:
+        params.append(('intermediate_commit', True))
 
     with closing(requestor.POST(action, params=params,
                                 stream=True)) as response:

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -113,7 +113,9 @@ class UpgradeTestCase(TestCase):
                 profileid, (six.text_type(version),))
         transaction.commit()
 
-    def install_profile_upgrades(self, *profileids):
+    def install_profile_upgrades(self, *profileids, **kwargs):
+        intermediate_commit = kwargs.pop('intermediate_commit', False)
+
         gatherer = queryAdapter(self.portal_setup, IUpgradeInformationGatherer)
         upgrade_info = [
             (profile['id'], list(map(itemgetter('id'), profile['upgrades'])))
@@ -121,7 +123,9 @@ class UpgradeTestCase(TestCase):
             if profile['id'] in profileids
         ]
         executioner = queryAdapter(self.portal_setup, IExecutioner)
-        executioner.install(upgrade_info)
+        executioner.install(
+            upgrade_info, intermediate_commit=intermediate_commit
+        )
 
     def record_installed_upgrades(self, profile, *destinations):
         profile = re.sub('^profile-', '', profile)

--- a/test-plone-5.2.x-py37.cfg
+++ b/test-plone-5.2.x-py37.cfg
@@ -5,3 +5,4 @@ package-name = ftw.upgrade
 
 [versions]
 importlib-metadata = 0.23
+collective.xmltestreport=2.0.2


### PR DESCRIPTION
When installing a lot of potentially long running upgrades at once we would sometimes like to be able to make sure that each individual upgrade is committed after it has been installed successfully.

For this purpose we add an `--intermediate-commit` flag. If it is toggled on a `commit` will be fired after each upgrade is installed.

Considerations:
- The flag is only available via command line and api. It has not been exposed in the upgrade view.
- The transaction notes will be split into several parts when installing upgrades. There is also a very short final transaction which mostly calls the after upgrade hooks. ![Screenshot 2021-06-21 at 12 14 20](https://user-images.githubusercontent.com/736583/122750611-07ec1200-d28f-11eb-90f4-1c62068b0d12.png)
- Writing the last installed version after an upgrade has been moved and will be performed after each upgrade step to make sure versions are correct in case of an abort or failure.
- The indexing queue is also flushed manually to make sure logging is in place and we see progress.

Jira: https://4teamwork.atlassian.net/browse/CA-2311
