### PR TITLE
Fix test comparing list against arbitrary order.

### DIFF
--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -325,8 +325,10 @@ class TestUpgradeStep(UpgradeTestCase):
                 brains = self.catalog_unrestricted_search(query)
 
                 testcase.assertEqual(2, len(brains))
-                testcase.assertEqual(['page-one', 'page-two'],
-                                     [brain.id for brain in brains])
+                testcase.assertEqual(
+                    {'page-one', 'page-two'},
+                    {brain.id for brain in brains}
+                )
                 testcase.assertEqual('ImplicitAcquisitionWrapper',
                                      type(brains[0]).__name__)
 
@@ -334,8 +336,10 @@ class TestUpgradeStep(UpgradeTestCase):
                     query, full_objects=True)
                 testcase.assertEqual(2, len(objects))
                 objects = list(objects)
-                testcase.assertEqual(['page-one', 'page-two'],
-                                     [obj.id for obj in objects])
+                testcase.assertEqual(
+                    {'page-one', 'page-two'},
+                    {obj.id for obj in objects}
+                )
                 testcase.assertEqual('ImplicitAcquisitionWrapper',
                                      type(objects[0]).__name__)
 


### PR DESCRIPTION
The order of catalog results is not guaranteed and without any sorting parameters order can be arbitrary. This test seems to be flaky occasionally and order is not relevant in this case. We are just interested in the result set but not the order in this case.