### PR TITLE
Truncate duration from log entries in tests.

### DIFF
--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -13,6 +13,7 @@ from ftw.upgrade.interfaces import IUpgradeStepRecorder
 from ftw.upgrade.testing import COMMAND_AND_UPGRADE_FUNCTIONAL_TESTING
 from ftw.upgrade.testing import COMMAND_LAYER
 from ftw.upgrade.testing import UPGRADE_FUNCTIONAL_TESTING
+from ftw.upgrade.tests.helpers import truncate_duration
 from ftw.upgrade.tests.helpers import verbose_logging
 from operator import itemgetter
 from path import Path
@@ -210,7 +211,7 @@ class UpgradeTestCase(TestCase):
         self.logger = None
 
     def get_log(self):
-        return self.log.getvalue().splitlines()
+        return truncate_duration(self.log.getvalue().splitlines())
 
     def purge_log(self):
         self.log.seek(0)

--- a/ftw/upgrade/tests/helpers.py
+++ b/ftw/upgrade/tests/helpers.py
@@ -65,3 +65,16 @@ def no_logging_threads():
         yield
     finally:
         logging.logThreads = original_log_threads
+
+
+def truncate_duration(lines):
+    duration_entry = u'Upgrade step duration:'
+    truncated = []
+    for line in lines:
+        if duration_entry in line:
+            line = u'{} XXX'.format(
+                line[:line.index(duration_entry) + len(duration_entry)]
+            )
+        truncated.append(line)
+    return truncated
+

--- a/ftw/upgrade/tests/test_command_install.py
+++ b/ftw/upgrade/tests/test_command_install.py
@@ -5,6 +5,7 @@ from ftw.upgrade import UpgradeStep
 from ftw.upgrade.indexing import HAS_INDEXING
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
 from ftw.upgrade.tests.helpers import no_logging_threads
+from ftw.upgrade.tests.helpers import truncate_duration
 from imp import reload
 from persistent.list import PersistentList
 from plone.app.testing import setRoles
@@ -215,16 +216,16 @@ class TestInstallCommand(CommandAndInstanceTestCase):
                 [u'ftw.upgrade: ______________________________________________________________________',
                  u'ftw.upgrade: UPGRADE STEP the.package:default: TriggerReindex',
                  u'ftw.upgrade: Ran upgrade step TriggerReindex for profile the.package:default',
-                 u'ftw.upgrade: Upgrade step duration: 1 second',
+                 u'ftw.upgrade: Upgrade step duration: XXX',
                  u'ftw.upgrade: 1 of 2 (50%): Processing indexing queue',
                  u'ftw.upgrade: Transaction has been committed.',
                  u'ftw.upgrade: ______________________________________________________________________',
                  u'ftw.upgrade: UPGRADE STEP the.package:default: Upgrade.',
                  u'ftw.upgrade: Ran upgrade step Upgrade. for profile the.package:default',
-                 u'ftw.upgrade: Upgrade step duration: 1 second',
+                 u'ftw.upgrade: Upgrade step duration: XXX',
                  u'ftw.upgrade: Transaction has been committed.',
                  u'Result: SUCCESS'],
-                output.splitlines())
+                truncate_duration(output.splitlines()))
 
     def test_failing_install_proposed_upgrades_of_profile_with_intermediate_commit(self):
         class Upgrade(UpgradeStep):
@@ -256,12 +257,12 @@ class TestInstallCommand(CommandAndInstanceTestCase):
                 [u'ftw.upgrade: ______________________________________________________________________',
                  u'ftw.upgrade: UPGRADE STEP the.package:default: Upgrade.',
                  u'ftw.upgrade: Ran upgrade step Upgrade. for profile the.package:default',
-                 u'ftw.upgrade: Upgrade step duration: 1 second',
+                 u'ftw.upgrade: Upgrade step duration: XXX',
                  u'ftw.upgrade: Transaction has been committed.',
                  u'ftw.upgrade: ______________________________________________________________________',
                  u'ftw.upgrade: UPGRADE STEP the.package:default: Upgrade',
                  u'ftw.upgrade: FAILED'],
-                output.splitlines()[:8])
+                truncate_duration(output.splitlines()[:8]))
             self.assertEqual(
                 [u'Result: FAILURE'],
                 output.splitlines()[-1:])

--- a/ftw/upgrade/tests/test_executioner.py
+++ b/ftw/upgrade/tests/test_executioner.py
@@ -7,10 +7,10 @@ from ftw.upgrade.indexing import HAS_INDEXING
 from ftw.upgrade.interfaces import IExecutioner
 from ftw.upgrade.tests.base import UpgradeTestCase
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import getFSVersionTuple
 from unittest import skipIf
 from zope.component import queryAdapter
 from zope.interface.verify import verifyClass
-from Products.CMFPlone.utils import getFSVersionTuple
 
 import transaction
 
@@ -311,13 +311,13 @@ class TestExecutioner(UpgradeTestCase):
                 [u'______________________________________________________________________',
                  u'UPGRADE STEP the.package:default: TriggerReindex',
                  u'Ran upgrade step TriggerReindex for profile the.package:default',
-                 u'Upgrade step duration: 1 second',
+                 u'Upgrade step duration: XXX',
                  u'1 of 2 (50%): Processing indexing queue',
                  u'Transaction has been committed.',
                  u'______________________________________________________________________',
                  u'UPGRADE STEP the.package:default: Upgrade.',
                  u'Ran upgrade step Upgrade. for profile the.package:default',
-                 u'Upgrade step duration: 1 second',
+                 u'Upgrade step duration: XXX',
                  u'Transaction has been committed.'],
                 self.get_log())
 


### PR DESCRIPTION
Asserting against runtime with no means of either overriding how we log during tests or how time is measured will lead to test failures when CPU time available is scarce.

As this has now happened several times we truncate concrete runtime from the logs only comparing against a placeholder.