### PR TITLE
Add method to iterate over brains in upgrade step.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add method to iterate over brains in upgrade step. [njohner]
 
 
 3.1.0 (2021-06-21)

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -83,6 +83,13 @@ class UpgradeStep(object):
         """
         return getToolByName(self.portal_setup, tool_name)
 
+    def _iterate_and_log(self, catalog_query, full_objects, message,
+                         logger=None, savepoints=None):
+        results = self.catalog_unrestricted_search(
+            catalog_query, full_objects=full_objects)
+        items = SavepointIterator.build(results, savepoints, logger)
+        return ProgressLogger(message, items, logger=logger)
+
     security.declarePrivate('objects')
     def objects(self, catalog_query, message, logger=None,
                 savepoints=None):
@@ -91,12 +98,20 @@ class UpgradeStep(object):
         The iterator configures and calls a ``ProgressLogger`` with the
         passed ``message``.
         """
+        return self._iterate_and_log(catalog_query, True, message,
+                                     logger=logger, savepoints=savepoints)
 
-        objects = self.catalog_unrestricted_search(
-            catalog_query, full_objects=True)
+    security.declarePrivate('brains')
+    def brains(self, catalog_query, message, logger=None,
+               savepoints=None):
+        """Queries the catalog (unrestricted) and creates an iterator
+        over the brains.
+        The iterator configures and calls a ``ProgressLogger`` with the
+        passed ``message``.
+        """
 
-        objects = SavepointIterator.build(objects, savepoints, logger)
-        return ProgressLogger(message, objects, logger=logger)
+        return self._iterate_and_log(catalog_query, False, message,
+                                     logger=logger, savepoints=savepoints)
 
     security.declarePrivate('catalog_rebuild_index')
     def catalog_rebuild_index(self, name):

--- a/ftw/upgrade/tests/test_upgrade_step_intids.py
+++ b/ftw/upgrade/tests/test_upgrade_step_intids.py
@@ -1,7 +1,7 @@
 from ftw.upgrade.testing import INTID_UPGRADE_FUNCTIONAL_TESTING
-from ftw.upgrade.tests.test_upgrade_step import TestUpgradeStep
+from ftw.upgrade.tests import test_upgrade_step
 
 
-class TestUpgradeStepIntids(TestUpgradeStep):
+class TestUpgradeStepIntids(test_upgrade_step.TestUpgradeStep):
 
     layer = INTID_UPGRADE_FUNCTIONAL_TESTING


### PR DESCRIPTION
I'm not sure why we don't have a method to iterate over the brains. We don't always want to get the objects.

For https://4teamwork.atlassian.net/browse/CA-2785