### PR TITLE
Improve memory management during upgrades

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Log memory usage during upgrade steps. [njohner]
+- Write upgrade step durations to a file. [njohner]
+- Sweep cache during upgrade if memory is critical. [njohner]
 
 
 3.1.1 (2021-09-07)

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -88,7 +88,7 @@ class Executioner(object):
             # the start.
             self.portal_setup.runAllImportStepsFromProfile(prefix + profile_id)
             logger.info('Done installing profile %s.', profile_id)
-            optimize_memory_usage()
+            optimize_memory_usage(logger)
         self._process_indexing_queue()
 
     security.declarePrivate('_register_after_commit_hook')

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -113,6 +113,7 @@ class Executioner(object):
         last_dest_version = None
 
         for upgradeid in upgradeids:
+            start = time.time()
             last_dest_version = self._do_upgrade(profileid, upgradeid) \
                 or last_dest_version
             self._set_portal_setup_version(profileid, last_dest_version)
@@ -122,6 +123,9 @@ class Executioner(object):
                 self._process_indexing_queue()
                 transaction.commit()
                 self._register_after_commit_hook()
+
+            logger.log(logging.INFO, 'Upgrade step duration: %s' % format_duration(
+                time.time() - start))
 
         self._set_quickinstaller_version(profileid)
 
@@ -155,8 +159,6 @@ class Executioner(object):
 
     security.declarePrivate('_do_upgrade')
     def _do_upgrade(self, profileid, upgradeid):
-        start = time.time()
-
         step = _upgrade_registry.getUpgradeStep(profileid, upgradeid)
         logger.log(logging.INFO, '_' * 70)
         logger.log(logging.INFO, 'UPGRADE STEP %s: %s' % (
@@ -168,9 +170,6 @@ class Executioner(object):
         msg = "Ran upgrade step %s for profile %s" % (
             step.title, profileid)
         logger.log(logging.INFO, msg)
-
-        logger.log(logging.INFO, 'Upgrade step duration: %s' % format_duration(
-                time.time() - start))
 
         return step.dest
 

--- a/ftw/upgrade/executioner.py
+++ b/ftw/upgrade/executioner.py
@@ -9,6 +9,7 @@ from ftw.upgrade.resource_registries import recook_resources
 from ftw.upgrade.transactionnote import TransactionNote
 from ftw.upgrade.utils import format_duration
 from ftw.upgrade.utils import get_sorted_profile_ids
+from ftw.upgrade.utils import log_memory_usage
 from ftw.upgrade.utils import optimize_memory_usage
 from Products.CMFCore.utils import getToolByName
 from Products.GenericSetup.interfaces import ISetupTool
@@ -126,6 +127,7 @@ class Executioner(object):
 
             logger.log(logging.INFO, 'Upgrade step duration: %s' % format_duration(
                 time.time() - start))
+            log_memory_usage(logger)
 
         self._set_quickinstaller_version(profileid)
 

--- a/ftw/upgrade/tests/base.py
+++ b/ftw/upgrade/tests/base.py
@@ -13,7 +13,7 @@ from ftw.upgrade.interfaces import IUpgradeStepRecorder
 from ftw.upgrade.testing import COMMAND_AND_UPGRADE_FUNCTIONAL_TESTING
 from ftw.upgrade.testing import COMMAND_LAYER
 from ftw.upgrade.testing import UPGRADE_FUNCTIONAL_TESTING
-from ftw.upgrade.tests.helpers import truncate_duration
+from ftw.upgrade.tests.helpers import truncate_memory_and_duration
 from ftw.upgrade.tests.helpers import verbose_logging
 from operator import itemgetter
 from path import Path
@@ -211,7 +211,7 @@ class UpgradeTestCase(TestCase):
         self.logger = None
 
     def get_log(self):
-        return truncate_duration(self.log.getvalue().splitlines())
+        return truncate_memory_and_duration(self.log.getvalue().splitlines())
 
     def purge_log(self):
         self.log.seek(0)

--- a/ftw/upgrade/tests/helpers.py
+++ b/ftw/upgrade/tests/helpers.py
@@ -67,14 +67,24 @@ def no_logging_threads():
         logging.logThreads = original_log_threads
 
 
-def truncate_duration(lines):
-    duration_entry = u'Upgrade step duration:'
+def truncate_value(message, lines):
     truncated = []
     for line in lines:
-        if duration_entry in line:
+        if message in line:
             line = u'{} XXX'.format(
-                line[:line.index(duration_entry) + len(duration_entry)]
+                line[:line.index(message) + len(message)]
             )
         truncated.append(line)
     return truncated
 
+
+def truncate_duration(lines):
+    return truncate_value(u'Upgrade step duration:', lines)
+
+
+def truncate_memory(lines):
+    return truncate_value(u'Current memory usage in MB (RSS):', lines)
+
+
+def truncate_memory_and_duration(lines):
+    return truncate_duration(truncate_memory(lines))

--- a/ftw/upgrade/tests/test_command_install.py
+++ b/ftw/upgrade/tests/test_command_install.py
@@ -5,7 +5,7 @@ from ftw.upgrade import UpgradeStep
 from ftw.upgrade.indexing import HAS_INDEXING
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
 from ftw.upgrade.tests.helpers import no_logging_threads
-from ftw.upgrade.tests.helpers import truncate_duration
+from ftw.upgrade.tests.helpers import truncate_memory_and_duration
 from imp import reload
 from persistent.list import PersistentList
 from plone.app.testing import setRoles
@@ -216,16 +216,18 @@ class TestInstallCommand(CommandAndInstanceTestCase):
                 [u'ftw.upgrade: ______________________________________________________________________',
                  u'ftw.upgrade: UPGRADE STEP the.package:default: TriggerReindex',
                  u'ftw.upgrade: Ran upgrade step TriggerReindex for profile the.package:default',
-                 u'ftw.upgrade: Upgrade step duration: XXX',
                  u'ftw.upgrade: 1 of 2 (50%): Processing indexing queue',
                  u'ftw.upgrade: Transaction has been committed.',
+                 u'ftw.upgrade: Upgrade step duration: XXX',
+                 u'ftw.upgrade: Current memory usage in MB (RSS): XXX',
                  u'ftw.upgrade: ______________________________________________________________________',
                  u'ftw.upgrade: UPGRADE STEP the.package:default: Upgrade.',
                  u'ftw.upgrade: Ran upgrade step Upgrade. for profile the.package:default',
-                 u'ftw.upgrade: Upgrade step duration: XXX',
                  u'ftw.upgrade: Transaction has been committed.',
+                 u'ftw.upgrade: Upgrade step duration: XXX',
+                 u'ftw.upgrade: Current memory usage in MB (RSS): XXX',
                  u'Result: SUCCESS'],
-                truncate_duration(output.splitlines()))
+                truncate_memory_and_duration(output.splitlines()))
 
     def test_failing_install_proposed_upgrades_of_profile_with_intermediate_commit(self):
         class Upgrade(UpgradeStep):
@@ -257,12 +259,13 @@ class TestInstallCommand(CommandAndInstanceTestCase):
                 [u'ftw.upgrade: ______________________________________________________________________',
                  u'ftw.upgrade: UPGRADE STEP the.package:default: Upgrade.',
                  u'ftw.upgrade: Ran upgrade step Upgrade. for profile the.package:default',
-                 u'ftw.upgrade: Upgrade step duration: XXX',
                  u'ftw.upgrade: Transaction has been committed.',
+                 u'ftw.upgrade: Upgrade step duration: XXX',
+                 u'ftw.upgrade: Current memory usage in MB (RSS): XXX',
                  u'ftw.upgrade: ______________________________________________________________________',
                  u'ftw.upgrade: UPGRADE STEP the.package:default: Upgrade',
                  u'ftw.upgrade: FAILED'],
-                truncate_duration(output.splitlines()[:8]))
+                truncate_memory_and_duration(output.splitlines()[:9]))
             self.assertEqual(
                 [u'Result: FAILURE'],
                 output.splitlines()[-1:])

--- a/ftw/upgrade/tests/test_executioner.py
+++ b/ftw/upgrade/tests/test_executioner.py
@@ -311,14 +311,16 @@ class TestExecutioner(UpgradeTestCase):
                 [u'______________________________________________________________________',
                  u'UPGRADE STEP the.package:default: TriggerReindex',
                  u'Ran upgrade step TriggerReindex for profile the.package:default',
-                 u'Upgrade step duration: XXX',
                  u'1 of 2 (50%): Processing indexing queue',
                  u'Transaction has been committed.',
+                 u'Upgrade step duration: XXX',
+                 u'Current memory usage in MB (RSS): XXX',
                  u'______________________________________________________________________',
                  u'UPGRADE STEP the.package:default: Upgrade.',
                  u'Ran upgrade step Upgrade. for profile the.package:default',
+                 u'Transaction has been committed.',
                  u'Upgrade step duration: XXX',
-                 u'Transaction has been committed.'],
+                 u'Current memory usage in MB (RSS): XXX'],
                 self.get_log())
 
     def test_installed_version_if_upgrade_fails_with_intermediate_commit(self):

--- a/ftw/upgrade/utils.py
+++ b/ftw/upgrade/utils.py
@@ -13,6 +13,7 @@ import re
 import stat
 import tarjan.tc
 import transaction
+import psutil
 
 
 def topological_sort(items, partial_order):
@@ -135,6 +136,7 @@ class SavepointIterator(object):
             if i % self.threshold == 0:
                 optimize_memory_usage()
                 self.logger.info("Created savepoint at %s items" % i)
+                log_memory_usage(self.logger)
             yield item
 
     def __len__(self):
@@ -177,6 +179,18 @@ class SavepointIterator(object):
             return value
         else:
             raise ValueError('Invalid savepoint threshold {!r}'.format(value))
+
+
+def get_memory_usage():
+    mem_info = psutil.Process().memory_info()
+    return mem_info.rss / 1024.0 ** 2.0
+
+
+def log_memory_usage(logger):
+    rss = get_memory_usage()
+    logger.log(
+        logging.INFO,
+        'Current memory usage in MB (RSS): {:0.1f}'.format(rss))
 
 
 def optimize_memory_usage():

--- a/ftw/upgrade/utils.py
+++ b/ftw/upgrade/utils.py
@@ -1,3 +1,4 @@
+from App.config import getConfiguration
 from collections import defaultdict
 from contextlib import contextmanager
 from copy import deepcopy
@@ -391,3 +392,22 @@ def get_portal_migration(context):
     """
     portal_migration = getattr(context, 'portal_migration')
     return portal_migration
+
+
+def get_logdir():
+    """Determine the log directory.
+    This will be derived from Zope2's EventLog location, in order to not
+    have to figure out the path to var/log/ ourselves.
+    """
+    zconf = getConfiguration()
+    eventlog = getattr(zconf, 'eventlog', None)
+
+    if eventlog is None:
+        return None
+
+    handler_factories = eventlog.handler_factories
+    eventlog_path = handler_factories[0].section.path
+    if not eventlog_path.endswith('.log'):
+        return None
+    log_dir = os.path.dirname(eventlog_path)
+    return log_dir

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(name='ftw.upgrade',
         'setuptools',
         'six >= 1.12.0',
         'tarjan',
+        'psutil',
 
         # Zope
         'AccessControl',


### PR DESCRIPTION
Changes here include:
- log memory during upgrades
- write upgrade step duration to statistics file
- check available resources during upgrades and sweep cache if memory is critical

For [CA-3284](https://4teamwork.atlassian.net/browse/CA-3284) and [CA-3289](https://4teamwork.atlassian.net/browse/CA-3289)