### PR TITLE
Allow choosing a specific instance to run upgrade commands.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-3.2.1 (unreleased)
+3.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow choosing a specific instance to run upgrade commands. [njohner]
 
 
 3.2.0 (2022-01-31)

--- a/ftw/upgrade/command/combine_bundles.py
+++ b/ftw/upgrade/command/combine_bundles.py
@@ -1,4 +1,5 @@
 from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
+from ftw.upgrade.command.jsonapi import add_requestor_instance_argument
 from ftw.upgrade.command.jsonapi import add_site_path_argument
 from ftw.upgrade.command.jsonapi import error_handling
 from ftw.upgrade.command.jsonapi import with_api_requestor
@@ -22,6 +23,7 @@ def setup_argparser(commands):
     )
     command.set_defaults(func=combine_bundles)
     add_requestor_authentication_argument(command)
+    add_requestor_instance_argument(command)
     add_site_path_argument(command)
 
 

--- a/ftw/upgrade/command/install.py
+++ b/ftw/upgrade/command/install.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from contextlib import closing
 from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
+from ftw.upgrade.command.jsonapi import add_requestor_instance_argument
 from ftw.upgrade.command.jsonapi import add_site_path_argument
 from ftw.upgrade.command.jsonapi import error_handling
 from ftw.upgrade.command.jsonapi import with_api_requestor
@@ -73,6 +74,7 @@ def setup_argparser(commands):
         description=DOCS)
     command.set_defaults(func=install_command)
     add_requestor_authentication_argument(command)
+    add_requestor_instance_argument(command)
     add_site_path_argument(command)
 
     command.add_argument('--force', '-f', action='store_true',

--- a/ftw/upgrade/command/jsonapi.py
+++ b/ftw/upgrade/command/jsonapi.py
@@ -90,6 +90,13 @@ def add_requestor_authentication_argument(argparse_command):
         help='Authentication information: "<username>:<password>"')
 
 
+def add_requestor_instance_argument(argparse_command):
+    argparse_command.add_argument(
+        '--instance',
+        help='instance that should be used for all requests. '
+             'If not specified the first running instance is used.')
+
+
 def add_site_path_argument(argparse_command):
     argparse_command.add_argument(
         '--verbose', '-v', action='store_true',
@@ -130,7 +137,8 @@ def with_api_requestor(func):
             auth = TempfileAuth()
 
         site = get_plone_site_by_args(args, APIRequestor(auth))
-        requestor = APIRequestor(auth, site=site)
+        requestor = APIRequestor(
+            auth, site=site, instance_name=getattr(args, 'instance', None))
         return func(args, requestor)
     func_wrapper.__name__ = func.__name__
     func_wrapper.__doc__ = func.__doc__

--- a/ftw/upgrade/command/list_cmd.py
+++ b/ftw/upgrade/command/list_cmd.py
@@ -1,5 +1,6 @@
 from ftw.upgrade.command.jsonapi import add_json_argument
 from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
+from ftw.upgrade.command.jsonapi import add_requestor_instance_argument
 from ftw.upgrade.command.jsonapi import add_site_path_argument
 from ftw.upgrade.command.jsonapi import error_handling
 from ftw.upgrade.command.jsonapi import with_api_requestor
@@ -46,6 +47,7 @@ def setup_argparser(commands):
         description=DOCS)
     command.set_defaults(func=list_command)
     add_requestor_authentication_argument(command)
+    add_requestor_instance_argument(command)
     add_site_path_argument(command)
     add_json_argument(command)
 

--- a/ftw/upgrade/command/plone_upgrade.py
+++ b/ftw/upgrade/command/plone_upgrade.py
@@ -1,5 +1,6 @@
 from contextlib import closing
 from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
+from ftw.upgrade.command.jsonapi import add_requestor_instance_argument
 from ftw.upgrade.command.jsonapi import add_site_path_argument
 from ftw.upgrade.command.jsonapi import error_handling
 from ftw.upgrade.command.jsonapi import with_api_requestor
@@ -29,6 +30,7 @@ def setup_argparser(commands):
         description=DOCS)
     command.set_defaults(func=plone_upgrade_command)
     add_requestor_authentication_argument(command)
+    add_requestor_instance_argument(command)
     add_site_path_argument(command)
 
 

--- a/ftw/upgrade/command/plone_upgrade_needed.py
+++ b/ftw/upgrade/command/plone_upgrade_needed.py
@@ -1,4 +1,5 @@
 from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
+from ftw.upgrade.command.jsonapi import add_requestor_instance_argument
 from ftw.upgrade.command.jsonapi import add_site_path_argument
 from ftw.upgrade.command.jsonapi import error_handling
 from ftw.upgrade.command.jsonapi import with_api_requestor
@@ -26,6 +27,7 @@ def setup_argparser(commands):
         description=DOCS)
     command.set_defaults(func=plone_upgrade_command)
     add_requestor_authentication_argument(command)
+    add_requestor_instance_argument(command)
     add_site_path_argument(command)
 
 

--- a/ftw/upgrade/command/recook.py
+++ b/ftw/upgrade/command/recook.py
@@ -1,4 +1,5 @@
 from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
+from ftw.upgrade.command.jsonapi import add_requestor_instance_argument
 from ftw.upgrade.command.jsonapi import add_site_path_argument
 from ftw.upgrade.command.jsonapi import error_handling
 from ftw.upgrade.command.jsonapi import with_api_requestor
@@ -21,6 +22,7 @@ def setup_argparser(commands):
         description=DOCS)
     command.set_defaults(func=recook_command)
     add_requestor_authentication_argument(command)
+    add_requestor_instance_argument(command)
     add_site_path_argument(command)
 
 

--- a/ftw/upgrade/command/sites.py
+++ b/ftw/upgrade/command/sites.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from ftw.upgrade.command.jsonapi import add_json_argument
 from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
+from ftw.upgrade.command.jsonapi import add_requestor_instance_argument
 from ftw.upgrade.command.jsonapi import error_handling
 from ftw.upgrade.command.jsonapi import with_api_requestor
 from ftw.upgrade.command.terminal import TERMINAL
@@ -28,6 +29,7 @@ def setup_argparser(commands):
         description=DOCS)
     command.set_defaults(func=sites_command)
     add_requestor_authentication_argument(command)
+    add_requestor_instance_argument(command)
     add_json_argument(command)
 
 

--- a/ftw/upgrade/command/user.py
+++ b/ftw/upgrade/command/user.py
@@ -1,4 +1,5 @@
 from ftw.upgrade.command.jsonapi import add_requestor_authentication_argument
+from ftw.upgrade.command.jsonapi import add_requestor_instance_argument
 from ftw.upgrade.command.jsonapi import error_handling
 from ftw.upgrade.command.jsonapi import with_api_requestor
 from ftw.upgrade.command.terminal import TERMINAL
@@ -23,6 +24,7 @@ def setup_argparser(commands):
         description=DOCS)
     command.set_defaults(func=sites_command)
     add_requestor_authentication_argument(command)
+    add_requestor_instance_argument(command)
 
 
 @with_api_requestor

--- a/ftw/upgrade/tests/test_command_install.py
+++ b/ftw/upgrade/tests/test_command_install.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.upgrade import UpgradeStep
+from ftw.upgrade.command import jsonapi
 from ftw.upgrade.indexing import HAS_INDEXING
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
 from ftw.upgrade.tests.helpers import no_logging_threads
@@ -361,6 +362,7 @@ class TestInstallCommand(CommandAndInstanceTestCase):
             output.splitlines())
 
     def test_instance_argument(self):
+        jsonapi.TIMEOUT = 5
         self.package.with_profile(
             Builder('genericsetup profile')
             .with_upgrade(Builder('ftw upgrade step').to(datetime(2011, 1, 1))))

--- a/ftw/upgrade/tests/test_command_install.py
+++ b/ftw/upgrade/tests/test_command_install.py
@@ -359,3 +359,22 @@ class TestInstallCommand(CommandAndInstanceTestCase):
         self.assertEqual(
             [u'ERROR: --force can only be used with --profiles.'],
             output.splitlines())
+
+    def test_instance_argument(self):
+        self.package.with_profile(
+            Builder('genericsetup profile')
+            .with_upgrade(Builder('ftw upgrade step').to(datetime(2011, 1, 1))))
+
+        with self.package_created():
+            self.install_profile('the.package:default', version='20110101000000')
+
+        exitcode, output = self.upgrade_script(
+            'install -s plone --proposed --instance=instance1',
+            assert_exitcode=False)
+
+        self.assertEqual(1, exitcode)
+        self.assertEqual(u'ERROR: No running Plone instance detected.\n', output)
+
+        exitcode, output = self.upgrade_script(
+            'install -s plone --proposed --instance=instance')
+        self.assertEqual(u'Result: SUCCESS\n', output)

--- a/ftw/upgrade/tests/test_command_list.py
+++ b/ftw/upgrade/tests/test_command_list.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from ftw.builder import Builder
+from ftw.upgrade.command import jsonapi
 from ftw.upgrade.tests.base import CommandAndInstanceTestCase
 from six.moves import map
 
@@ -265,6 +266,7 @@ class TestListCommand(CommandAndInstanceTestCase):
             self.assertIn('INFO: Acting on site /plone', output)
 
     def test_instance_argument(self):
+        jsonapi.TIMEOUT = 5
         self.package.with_profile(
             Builder('genericsetup profile')
             .with_upgrade(Builder('ftw upgrade step').to(datetime(2011, 1, 1))))

--- a/ftw/upgrade/tests/test_command_list.py
+++ b/ftw/upgrade/tests/test_command_list.py
@@ -263,3 +263,22 @@ class TestListCommand(CommandAndInstanceTestCase):
             self.assertIn('Proposed upgrades', output)
             self.assertIn('20110101000000@the.package:default', output)
             self.assertIn('INFO: Acting on site /plone', output)
+
+    def test_instance_argument(self):
+        self.package.with_profile(
+            Builder('genericsetup profile')
+            .with_upgrade(Builder('ftw upgrade step').to(datetime(2011, 1, 1))))
+
+        with self.package_created():
+            self.install_profile('the.package:default', version='20110101000000')
+            self.clear_recorded_upgrades('the.package:default')
+
+        exitcode, output = self.upgrade_script(
+            'list --upgrades -s plone --json --instance=instance1',
+            assert_exitcode=False)
+        self.assertEqual(1, exitcode)
+        self.assertEqual(u'ERROR: No running Plone instance detected.\n', output)
+
+        exitcode, output = self.upgrade_script(
+            'list --upgrades -s plone --json --instance=instance')
+        self.assertEqual(1, len(json.loads(output)))


### PR DESCRIPTION
Upgrade commands were implemented in such a way that the requests would be made to the first running instance (sorted by name). Normally this should be `instance0`, but because upgrade commands usually get run after restarting the instances, if `instance0` is not reachable yet (for example it is still starting), then another instance would be used. This can be problematic as the other instances might not have been restarted yet (see for example [the update_plone script](https://github.com/4teamwork/opengever-deployments/blob/master/deploy/update_plone#L93)). To remedy this issue we now allow forcing the commands to run on a given instance. Moreover to better handle the case where instances might be restarting, we now retry accessing them until a timeout (of 1 minute) is reached.

For https://4teamwork.atlassian.net/browse/CA-2876