### PR TITLE
Pin certifi for plone 4.3.7

### DIFF
--- a/test-plone-4.3.7.cfg
+++ b/test-plone-4.3.7.cfg
@@ -19,3 +19,4 @@ Products.DateRecurringIndex = 2.1
 collective.elephantvocabulary = 0.2.5
 plone.formwidget.querystring = 1.1.10
 plone.event = 1.3.3
+certifi = < 2021.10.08


### PR DESCRIPTION
Nightlies have been failing for some time. `certify` has dropped support for pyhton 2 in version [2020.04.05.2](https://github.com/certifi/python-certifi/releases/tag/2020.04.05.2), but definitely broken the package for python 3 when introducing type annotations (https://github.com/certifi/python-certifi/commit/5f09ea84b97202a41430fed5bb3cbd489d04c18e). 