### PR TITLE
Allow to register upgrade steps in multiple directories

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,7 +2,6 @@ Changelog
 =========
 
 
-3.3.2 (unreleased)
 3.4.0 (unreleased)
 ------------------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,9 +3,12 @@ Changelog
 
 
 3.3.2 (unreleased)
+3.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added the possibility to group upgrade steps in subdirectories.
+  Fixes `issue 217 <https://github.com/4teamwork/ftw.upgrade/issues/217>`.
+  [ale-rt]
 
 
 3.3.1 (2022-07-08)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '3.3.2.dev0'
+version = '3.4.0.dev0'
 
 tests_require = [
     'ftw.testing >= 2.0.0.dev0',


### PR DESCRIPTION
It allows to specify upgrades in multiple folders:
```
    <upgrade-step:directory
        profile="my.package:default"
        directory="v1"
        />
    <upgrade-step:directory
        profile="my.package:default"
        directory="v2"
        />
```

Fixes #217

