### PR TITLE
Support dead brains in WorkflowSecurityUpdater.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support dead brains in WorkflowSecurityUpdater. [njohner]
 
 
 3.3.0 (2022-03-28)

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -367,7 +367,6 @@ class UpgradeStep(object):
             return (quickinstaller.isProductInstallable(product_name)
                     and quickinstaller.isProductInstalled(product_name))
 
-
     security.declarePrivate('uninstall_product')
     def uninstall_product(self, product_name):
         """Uninstalls a product using the quick installer.
@@ -426,7 +425,7 @@ class UpgradeStep(object):
         # ... as well as subscribers
         layer_subscribers = subscribers[0][ILocalBrowserLayerType]
         remaining_layers = tuple([layer for layer in layer_subscribers['']
-                                if not layer.__name__ == iface_name])
+                                  if not layer.__name__ == iface_name])
         layer_subscribers[''] = remaining_layers
 
         sm._utility_registrations.pop((ILocalBrowserLayerType, name), None)

--- a/ftw/upgrade/step.py
+++ b/ftw/upgrade/step.py
@@ -68,6 +68,7 @@ class UpgradeStep(object):
         self.associated_profile = associated_profile
         self.base_profile = base_profile
         self.target_version = target_version
+        self.catalog = self.getToolByName('portal_catalog')
 
     security.declarePrivate('__call__')
     def __call__(self):
@@ -117,14 +118,13 @@ class UpgradeStep(object):
     def catalog_rebuild_index(self, name):
         """Reindex the ``portal_catalog`` index identified by ``name``.
         """
-        catalog = self.getToolByName('portal_catalog')
         LOG.info("Reindexing index %s" % name)
 
         # pylint: disable=W0212
-        pgthreshold = catalog._getProgressThreshold() or 100
+        pgthreshold = self.catalog._getProgressThreshold() or 100
         # pylint: enable=W0212
         pghandler = ZLogHandler(pgthreshold)
-        catalog.reindexIndex(name, None, pghandler=pghandler)
+        self.catalog.reindexIndex(name, None, pghandler=pghandler)
 
         LOG.info("Reindexing index %s DONE" % name)
 
@@ -154,23 +154,20 @@ class UpgradeStep(object):
     def catalog_has_index(self, name):
         """Returns whether there is a catalog index ``name``.
         """
-        catalog = self.getToolByName('portal_catalog')
-        index_names = catalog.indexes()
+        index_names = self.catalog.indexes()
         return name in index_names
 
     security.declarePrivate('catalog_add_index')
     def catalog_add_index(self, name, type_, extra=None):
         """Adds a new index to the ``portal_catalog`` tool.
         """
-        catalog = self.getToolByName('portal_catalog')
-        return catalog.addIndex(name, type_, extra=extra)
+        return self.catalog.addIndex(name, type_, extra=extra)
 
     security.declarePrivate('catalog_remove_index')
     def catalog_remove_index(self, name):
         """Removes an index to from ``portal_catalog`` tool.
         """
-        catalog = self.getToolByName('portal_catalog')
-        return catalog.delIndex(name)
+        return self.catalog.delIndex(name)
 
     security.declarePrivate('catalog_unrestricted_get_object')
     def catalog_unrestricted_get_object(self, brain):
@@ -182,8 +179,7 @@ class UpgradeStep(object):
             LOG.warning('The object of the brain with rid {!r} no longer'
                         ' exists at the path {!r}; removing the brain.'.format(
                             brain.getRID(), brain.getPath()))
-            catalog = self.getToolByName('portal_catalog')
-            catalog.uncatalog_object(brain.getPath())
+            self.catalog.uncatalog_object(brain.getPath())
             return None
 
     security.declarePrivate('catalog_unrestricted_search')
@@ -192,8 +188,7 @@ class UpgradeStep(object):
         If `full_objects` is `True`, objects instead of brains
         are returned.
         """
-        catalog = self.getToolByName('portal_catalog')
-        brains = tuple(catalog.unrestrictedSearchResults(query))
+        brains = tuple(self.catalog.unrestrictedSearchResults(query))
 
         if full_objects:
             generator = (self.catalog_unrestricted_get_object(brain)

--- a/ftw/upgrade/tests/test_upgrade_step.py
+++ b/ftw/upgrade/tests/test_upgrade_step.py
@@ -316,7 +316,8 @@ class TestUpgradeStep(UpgradeTestCase):
             def __call__(self):
                 brains = self.get_folder_brains()
                 testcase.assertEqual(1, len(brains))
-                brain ,= brains
+                brain, = brains
+                path = brain.getPath()
 
                 testcase.assertIsNone(
                     self.catalog_unrestricted_get_object(brain),
@@ -331,6 +332,11 @@ class TestUpgradeStep(UpgradeTestCase):
                 testcase.assertEqual(
                     0, len(self.get_folder_brains()),
                     'Brain should have been uncataloged at this point.')
+
+                testcase.assertEqual(
+                    [{'type': 'Inexistant brain', 'path': path}],
+                    self.safe_object_getter.errors,
+                    'Failing brains should get collected in the object getter.')
 
             def get_folder_brains(self):
                 return self.catalog_unrestricted_search({'portal_type': 'Folder'})

--- a/test-plone-4.3.7.cfg
+++ b/test-plone-4.3.7.cfg
@@ -13,6 +13,7 @@ package-name = ftw.upgrade
 [versions]
 i18ndude = 4.3
 argcomplete = < 2.0.0
+requests = < 2.28
 
 # p.a.contenttypes dependencies not pinned in 4.3.7 yet
 Products.DateRecurringIndex = 2.1


### PR DESCRIPTION
I also fix the failing nightly build for plone 4.3.7.

Note that I collect information about broken brains but don't do anything with it yet. It could be used in specific upgrade steps though to log all brains that have failed once the upgrade is through.

For https://4teamwork.atlassian.net/browse/CA-4112