### PR TITLE
Allow to register upgrade steps in multiple directories

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,12 @@ Changelog
 =========
 
 
-3.3.2 (unreleased)
+3.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added the possibility to group upgrade steps in subdirectories.
+  Fixes `issue 217 <https://github.com/4teamwork/ftw.upgrade/issues/217>`.
+  [ale-rt]
 
 
 3.3.1 (2022-07-08)

--- a/ftw/upgrade/directory/zcml.py
+++ b/ftw/upgrade/directory/zcml.py
@@ -18,6 +18,9 @@ import os
 import zope.schema
 
 
+MIN_VERSION = str(10 ** 13)
+
+
 class IUpgradeStepDirectoryDirective(Interface):
 
     profile = zope.schema.TextLine(
@@ -45,7 +48,7 @@ def upgrade_step_directory_handler(context, profile, directory,
             .split(os.sep))
 
     context.action(
-        discriminator=('upgrade-step:directory', profile),
+        discriminator=('upgrade-step:directory', profile, dottedname),
         callable=upgrade_step_directory_action,
         args=(profile, dottedname, context.path(directory),
               soft_dependencies))
@@ -62,7 +65,14 @@ def upgrade_step_directory_action(profile, dottedname, path,
             ' upgrade step directory.'.format(profile))
 
     profileinfo = _profile_registry.getProfileInfo(profile)
-    if profileinfo.get('version', None) is not None:
+
+    # Check that no version is set for the profile in the metadata.xml
+    # The profile can still have a version set by ftw.upgrade in a previous run
+    # of this action
+    if (
+        "ftw.upgrade:dependencies" not in profileinfo
+        and profileinfo.get("version", None) is not None
+    ):
         raise UpgradeStepConfigurationError(
             'Registering an upgrades directory for "{0}" requires this profile'
             ' to not define a version in its metadata.xml.'
@@ -105,7 +115,22 @@ def upgrade_step_directory_action(profile, dottedname, path,
         last_version = upgrade_info['target-version']
 
     profile = GlobalRegistryStorage(IProfile).get(profile)
-    profile['version'] = last_version
+    profile['version'] = max(last_version, profile.get('version', MIN_VERSION))
+
+    # Combine the soft dependencies with the one we might have already
+    # due to this action setting them in a previous run
+    existing_soft_dependencies = profile.get('ftw.upgrade:dependencies')
+    if existing_soft_dependencies:
+        if soft_dependencies:
+            soft_dependencies = (
+                [
+                    dependency for dependency in soft_dependencies
+                    if dependency not in existing_soft_dependencies
+                ] + existing_soft_dependencies
+            )
+        else:
+            soft_dependencies = existing_soft_dependencies
+
     profile['ftw.upgrade:dependencies'] = soft_dependencies
 
 
@@ -126,4 +151,4 @@ def find_start_version(profile):
     if dests:
         return max(dests)
     else:
-        return str(10 ** 13)
+        return MIN_VERSION

--- a/ftw/upgrade/tests/test_directory_meta_directive.py
+++ b/ftw/upgrade/tests/test_directory_meta_directive.py
@@ -14,6 +14,7 @@ from zope.interface import Interface
 from zope.interface import providedBy
 
 import six
+import os
 
 
 class IFoo(Interface):
@@ -44,6 +45,24 @@ class TestDirectoryMetaDirective(UpgradeTestCase):
 
                     {'source': ('20110101080000',),
                      'dest': ('20110202080000',),
+                     'title': u'Remove action.'}])
+
+    def test_upgrade_steps_are_registered_multiple_sources(self):
+        self.profile.with_upgrade(Builder('ftw upgrade step')
+                                  .to(os.path.join("v2011", "20110101080000"))
+                                  .named('add_action'))
+        self.profile.with_upgrade(Builder('ftw upgrade step')
+                                  .to(os.path.join("v2012", "20120101080000"))
+                                  .named('remove_action'))
+
+        with self.package_created():
+            self.assert_upgrades([
+                    {'source': ('10000000000000',),
+                     'dest': ('20110101080000',),
+                     'title': u'Add action.'},
+
+                    {'source': ('20110101080000',),
+                     'dest': ('20120101080000',),
                      'title': u'Remove action.'}])
 
     def test_first_source_version_is_last_regulare_upgrade_step(self):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '3.3.2.dev0'
+version = '3.4.0.dev0'
 
 tests_require = [
     'ftw.testing >= 2.0.0.dev0',


### PR DESCRIPTION
It allows to specify upgrades in multiple folders:
```
    <upgrade-step:directory
        profile="my.package:default"
        directory="v1"
        />
    <upgrade-step:directory
        profile="my.package:default"
        directory="v2"
        />
```

Fixes #217

Replaces #226 